### PR TITLE
Beginnings of ONLY Stanford changes to wayback-core files

### DIFF
--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>openwayback</artifactId>
+    <groupId>org.netpreserve.openwayback</groupId>
+    <version>2.0.0</version>
+  </parent>
+
+  <groupId>edu.stanford.dlss</groupId>
+  <artifactId>swap-wayback-core</artifactId>
+  <name>Stanford Specific Wayback Core Java Classes</name>
+  <version>2.0.0</version>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.netpreserve.openwayback</groupId>
+      <artifactId>openwayback-cdx-server</artifactId>
+      <classifier>classes</classifier>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.netpreserve.openwayback</groupId>
+      <artifactId>openwayback-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+    	<groupId>javax.mail</groupId>
+    	<artifactId>mail</artifactId>
+    	<version>1.4.7</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <version>2.5.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/wayback-core/src/main/java/edu/stanford/dlss/contact/EmailProcessor.java
+++ b/wayback-core/src/main/java/edu/stanford/dlss/contact/EmailProcessor.java
@@ -1,0 +1,69 @@
+package edu.stanford.dlss.contact;
+import java.util.*;
+import javax.mail.*;
+import javax.mail.internet.*;
+
+public class EmailProcessor {
+
+
+    public boolean sendEmail(String from, String subject, String body) {
+    	if(!isValidEmail(from)){
+    		from = "admin@wayback.stanford.edu";
+    	}
+        
+        String to = "sul-was-support@lists.stanford.edu";
+
+        // Assuming you are sending email from localhost
+        String host = "localhost";
+
+        // Get system properties
+        Properties properties = System.getProperties();
+
+        // Setup mail server
+        properties.setProperty("mail.smtp.host", host);
+
+        // Get the default Session object.
+        Session session = Session.getDefaultInstance(properties);
+
+        try{
+           // Create a default MimeMessage object.
+           MimeMessage message = new MimeMessage(session);
+
+           // Set From: header field of the header.
+           message.setFrom(new InternetAddress(from));
+
+           // Set To: header field of the header.
+           message.addRecipient(Message.RecipientType.TO,
+                                    new InternetAddress(to));
+
+           // Set Subject: header field
+           message.setSubject(subject);
+
+           // Now set the actual message
+           message.setText(body);
+
+           // Send message
+           Transport.send(message);
+           System.out.println("Sent message successfully....");
+           return true;
+        }catch (Exception mex) {
+           mex.printStackTrace();
+           return false;
+        }
+    	
+    }
+    
+    private boolean isValidEmail(String emailAddress){
+    	boolean isValid = false;
+    	if(emailAddress != null && emailAddress.length() > 5){
+			try {
+				InternetAddress internetAddress = new InternetAddress(emailAddress);
+				internetAddress.validate();
+				isValid = true;
+			} catch (AddressException e) {
+				System.out.println("The from email is not valid " + emailAddress);
+			}
+		}
+		return isValid;
+    }
+}

--- a/wayback-core/src/main/java/edu/stanford/dlss/contact/EmailServlet.java
+++ b/wayback-core/src/main/java/edu/stanford/dlss/contact/EmailServlet.java
@@ -1,0 +1,80 @@
+package edu.stanford.dlss.contact;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.*;
+import javax.servlet.http.*;
+
+public class EmailServlet extends HttpServlet {
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+    	
+    	
+        String to = request.getParameter("email");
+        String name = request.getParameter("fullname");
+        String subject = request.getParameter("subject");
+        String body = request.getParameter("message");
+        
+        response.setContentType("text/html;charset=UTF-8");
+        
+        EmailProcessor mailer = new EmailProcessor();
+        boolean email_status = mailer.sendEmail(to, subject, body);
+        
+        PrintWriter out = response.getWriter();
+        
+        try {
+        	 if(email_status){
+	        	out.println("<h4>Feedback Submitted</h4>");
+	            out.println("<p>Thanks "+name+" for your feedback.</p>");
+        	 } else {
+             	out.println("<h4>Feedback not Submitted</h4>");
+                out.println("<p>There was a technical problem in sending your feedback. Please contact us on <a href=\"mailto:sul-was-support@lists.stanford.edu\">sul-was-support@lists.stanford.edu</a></p>");
+        	 }
+        } finally {
+            out.close();
+        }
+
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /**
+     * Handles the HTTP
+     * <code>GET</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Handles the HTTP
+     * <code>POST</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Returns a short description of the servlet.
+     *
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "This servlet is responsible of sending feedback email to support team.";
+    }
+}

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
@@ -197,6 +197,9 @@ public class ArchivalUrlSAXRewriteReplayRenderer implements ReplayRenderer {
     String.valueOf(utf8Bytes.length));
     headers.put(TextReplayRenderer.GUESSED_CHARSET_HEADER, charSet);
 
+    // Add X-UA-Compatible header for IE to render the page with latest standard
+    headers.put("X-UA-Compatible", "IE=edge");
+
     // send back the headers:
     HttpHeaderOperation.sendHeaders(headers, httpResponse);
     // Tomcat will always send a charset... It's trying to be smarter than

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
@@ -1,0 +1,273 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.wayback.archivalurl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.archive.wayback.ReplayRenderer;
+import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.CaptureSearchResults;
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.exception.WaybackException;
+import org.archive.wayback.replay.HttpHeaderOperation;
+import org.archive.wayback.replay.HttpHeaderProcessor;
+import org.archive.wayback.replay.JSPExecutor;
+import org.archive.wayback.replay.TagMagix;
+import org.archive.wayback.replay.TextReplayRenderer;
+import org.archive.wayback.replay.charset.CharsetDetector;
+import org.archive.wayback.replay.charset.StandardCharsetDetector;
+import org.archive.wayback.replay.html.ContextResultURIConverterFactory;
+import org.archive.wayback.replay.html.IdentityResultURIConverterFactory;
+import org.archive.wayback.replay.html.ReplayParseContext;
+import org.archive.wayback.util.htmllex.ContextAwareLexer;
+import org.archive.wayback.util.htmllex.ParseEventHandler;
+import org.htmlparser.Node;
+import org.htmlparser.lexer.Lexer;
+import org.htmlparser.lexer.Page;
+import org.htmlparser.util.ParserException;
+
+/**
+ * ReplayRenderer which attempts to rewrite text/html documents so URLs 
+ * references within the document load from the correct ArchivalURL AccessPoint.
+ * 
+ * @author brad
+ *
+ */
+public class ArchivalUrlSAXRewriteReplayRenderer implements ReplayRenderer {
+	private ParseEventHandler delegator = null;
+	private HttpHeaderProcessor httpHeaderProcessor;
+	private CharsetDetector charsetDetector = new StandardCharsetDetector();
+	private ContextResultURIConverterFactory converterFactory = null;
+	private boolean rewriteHttpsOnly;
+	
+	private final static String OUTPUT_CHARSET = "utf-8";
+	private static int FRAMESET_SCAN_BUFFER_SIZE = 16 * 1024;
+	private static ReplayRenderer frameWrappingRenderer = null;
+	public static ReplayRenderer getFrameWrappingRenderer() {
+		return frameWrappingRenderer;
+	}
+
+	public static void setFrameWrappingRenderer(ReplayRenderer frameWrappingRenderer) {
+		ArchivalUrlSAXRewriteReplayRenderer.frameWrappingRenderer = frameWrappingRenderer;
+	}
+
+	/**
+	 * @param httpHeaderProcessor which should process HTTP headers
+	 */
+	public ArchivalUrlSAXRewriteReplayRenderer(HttpHeaderProcessor httpHeaderProcessor) {
+		this.httpHeaderProcessor = httpHeaderProcessor;
+	}
+
+	// assume this is only called for appropriate doc types: html
+	public void renderResource(HttpServletRequest httpRequest,
+			HttpServletResponse httpResponse, WaybackRequest wbRequest,
+			CaptureSearchResult result, Resource resource,
+			ResultURIConverter uriConverter, CaptureSearchResults results)
+					throws ServletException, IOException, WaybackException {
+		renderResource(httpRequest, httpResponse, wbRequest, result, resource,
+				resource, uriConverter, results);
+	}
+
+	@Override
+	public void renderResource(HttpServletRequest httpRequest,
+			HttpServletResponse httpResponse, WaybackRequest wbRequest,
+			CaptureSearchResult result, Resource httpHeadersResource,
+			Resource payloadResource, ResultURIConverter uriConverter,
+			CaptureSearchResults results) throws ServletException, IOException,
+			WaybackException {
+
+		Resource decodedResource = TextReplayRenderer.decodeResource(httpHeadersResource, payloadResource);
+
+		// The URL of the page, for resolving in-page relative URLs: 
+		URL url = null;
+		try {
+			url = new URL(result.getOriginalUrl());
+		} catch (MalformedURLException e1) {
+			// TODO: this shouldn't happen...
+			e1.printStackTrace();
+			throw new IOException(e1.getMessage());
+		}
+		// determine the character set used to encode the document bytes:
+		String charSet = charsetDetector.getCharset(httpHeadersResource, decodedResource, wbRequest);
+
+		ContextResultURIConverterFactory fact = createConverterFactory(uriConverter, httpRequest, wbRequest);
+		
+		// set up the context:
+		ReplayParseContext context = 
+				new ReplayParseContext(fact,url,result.getCaptureTimestamp());
+		
+		context.setRewriteHttpsOnly(rewriteHttpsOnly);
+
+		if(!wbRequest.isFrameWrapperContext()) {
+			// in case this is an HTML page with FRAMEs, peek ahead an look:
+			// TODO: make ThreadLocal:
+			byte buffer[] = new byte[FRAMESET_SCAN_BUFFER_SIZE];
+
+			decodedResource.mark(FRAMESET_SCAN_BUFFER_SIZE);
+			int amtRead = decodedResource.read(buffer);
+			decodedResource.reset();
+
+			if(amtRead > 0) {
+				StringBuilder foo = new StringBuilder(new String(buffer,charSet));
+				int frameIdx = TagMagix.getEndOfFirstTag(foo, "FRAMESET");
+				if(frameIdx != -1) {
+					// insert flag so we don't add FRAMESET:
+					context.putData(FastArchivalUrlReplayParseEventHandler.FERRET_DONE_KEY,"");
+
+//					// top-level Frameset: Draw the frame wrapper thingy:
+//					frameWrappingRenderer.renderResource(httpRequest, 
+//							httpResponse, wbRequest, result, resource, 
+//							uriConverter, results);
+//					return;
+				}
+			}
+		}
+
+
+		// copy the HTTP response code:
+		HttpHeaderOperation.copyHTTPMessageHeader(httpHeadersResource, httpResponse);
+
+		// transform the original headers according to our headerProcessor:
+		Map<String,String> headers = HttpHeaderOperation.processHeaders(
+				httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+
+		// prepare several objects for the parse:
+
+		// a JSPExecutor:
+		JSPExecutor jspExec = new JSPExecutor(uriConverter, httpRequest, 
+				httpResponse, wbRequest, results, result, decodedResource);
+
+
+		// To make sure we get the length, we have to buffer it all up...
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+		context.setOutputCharset(OUTPUT_CHARSET);
+		context.setOutputStream(baos);
+		context.setJspExec(jspExec);
+
+
+		// and finally, parse, using the special lexer that knows how to
+		// handle javascript blocks containing unescaped HTML entities:
+		Page lexPage = new Page(decodedResource,charSet);
+		Lexer lexer = new Lexer(lexPage);
+		Lexer.STRICT_REMARKS = false;
+		ContextAwareLexer lex = new ContextAwareLexer(lexer, context);
+		Node node;
+		try {
+			delegator.handleParseStart(context);
+			while((node = lex.nextNode()) != null) {
+				delegator.handleNode(context, node);
+			}
+			delegator.handleParseComplete(context);
+		} catch (ParserException e) {
+			e.printStackTrace();
+			throw new IOException(e.getMessage());
+		}
+
+		// At this point, baos contains the utf-8 encoded bytes of our result:
+		byte[] utf8Bytes = baos.toByteArray();
+		// set the corrected length:
+		headers.put(HttpHeaderOperation.HTTP_LENGTH_HEADER, 
+				String.valueOf(utf8Bytes.length));
+		headers.put(TextReplayRenderer.GUESSED_CHARSET_HEADER, charSet);
+
+		// send back the headers:
+		HttpHeaderOperation.sendHeaders(headers, httpResponse);
+		// Tomcat will always send a charset... It's trying to be smarter than
+		// we are. If the original page didn't include a "charset" as part of
+		// the "Content-Type" HTTP header, then Tomcat will use the default..
+		// who knows what that is, or what that will do to the page..
+		// let's try explicitly setting it to what we used:
+		httpResponse.setCharacterEncoding(OUTPUT_CHARSET);
+		httpResponse.getOutputStream().write(utf8Bytes);
+	}
+	
+	protected ContextResultURIConverterFactory createConverterFactory(ResultURIConverter uriConverter, HttpServletRequest httpRequest, WaybackRequest wbRequest)
+	{
+		// sam ecode in ArchivalURLJSStringTransformerReplayRenderer
+		ContextResultURIConverterFactory fact = null;
+		
+		if (uriConverter instanceof ArchivalUrlResultURIConverter) {
+			fact = new ArchivalUrlContextResultURIConverterFactory(
+					(ArchivalUrlResultURIConverter) uriConverter);
+		} else if (converterFactory != null) {
+			fact = converterFactory;
+		} else {
+			fact = new IdentityResultURIConverterFactory(uriConverter);			
+		}
+		
+		return fact;
+	}
+
+	/**
+	 * @return the charsetDetector
+	 */
+	public CharsetDetector getCharsetDetector() {
+		return charsetDetector;
+	}
+
+	/**
+	 * @param charsetDetector the charsetDetector to set
+	 */
+	public void setCharsetDetector(CharsetDetector charsetDetector) {
+		this.charsetDetector = charsetDetector;
+	}
+
+	/**
+	 * @return the delegator
+	 */
+	public ParseEventHandler getDelegator() {
+		return delegator;
+	}
+
+	/**
+	 * @param delegator the delegator to set
+	 */
+	public void setDelegator(ParseEventHandler delegator) {
+		this.delegator = delegator;
+	}
+
+	public ContextResultURIConverterFactory getConverterFactory() {
+		return converterFactory;
+	}
+
+	public void setConverterFactory(
+			ContextResultURIConverterFactory converterFactory) {
+		this.converterFactory = converterFactory;
+	}
+
+	public boolean isRewriteHttpsOnly() {
+		return rewriteHttpsOnly;
+	}
+
+	public void setRewriteHttpsOnly(boolean rewriteHttpsOnly) {
+		this.rewriteHttpsOnly = rewriteHttpsOnly;
+	}
+}

--- a/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
@@ -1,0 +1,87 @@
+package org.archive.wayback.partition;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.UIResults;
+import org.archive.wayback.util.graph.Graph;
+import org.archive.wayback.util.graph.GraphEncoder;
+import org.archive.wayback.util.graph.RegionData;
+import org.archive.wayback.util.graph.RegionGraphElement;
+import org.archive.wayback.util.partition.Partition;
+import org.archive.wayback.util.partition.PartitionSize;
+import org.archive.wayback.util.partition.Partitioner;
+
+/**
+* Stanford replacement for ToolBarData;  presumably in this package to ease
+* effort to integrate Stanford version with existing core code.
+*/
+public class InteractiveToolBarData extends ToolBarData {
+	
+	private static final PartitionSize daySize = Partitioner.daySize;
+
+	private static final CaptureSearchResultPartitionMap dayMap = 
+			new CaptureSearchResultPartitionMap();
+	private static final Partitioner<CaptureSearchResult> dayPartitioner = 
+			new Partitioner<CaptureSearchResult>(dayMap);
+	
+	public List<Partition<CaptureSearchResult>> dayPartitions;
+
+	public String firstResultReplayUrl;
+	public String lastResultReplayUrl;
+	
+	public InteractiveToolBarData(UIResults uiResults) {
+		//super(uiResults);
+		this.uiResults = uiResults;
+		fmt = uiResults.getWbRequest().getFormatter();
+		results = uiResults.getCaptureResults();
+		curResult = uiResults.getResult();
+		findRelativeLinks();
+
+		Date firstDate = uiResults.getWbRequest().getStartDate();
+		Date lastDate = uiResults.getWbRequest().getEndDate();
+		yearPartitions = yearPartitioner.getRange(yearSize,firstDate,lastDate);
+	
+		Date firstYearDate = yearPartitions.get(0).getStart();
+		Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
+		dayPartitions =
+				dayPartitioner.getRange(daySize,firstYearDate,lastYearDate);
+		
+		Iterator<CaptureSearchResult> it = results.iterator();
+		
+		firstResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getFirst()));
+		lastResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getLast()));
+		
+		dayPartitioner.populate(dayPartitions,it);
+		yearPartitioner.populate(yearPartitions,dayPartitions.iterator());
+	}
+	
+	/**
+	 * @param formatKey String template for format Dates
+	 * @param width pixel width of resulting graph
+	 * @param height pixel height of resulting graph
+	 * @return String argument which will generate a graph for the results
+	 */
+	public String computeGraphString(String formatKey, int width, int height) {
+		Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions,
+				fmt,formatKey,width,height);
+		
+		RegionGraphElement rge[] = graph.getRegions();
+		RegionData data[] = new RegionData[rge.length];
+		for(int i = 0; i < data.length; i++) {
+			data[i] = rge[i].getData();
+			
+			for(int j=0; j<data[i].getValues().length;j++){
+			//	System.out.print(data[i].getValues()[j]+"");
+			}
+			
+			//System.out.println();
+		}
+		
+		return GraphEncoder.encode(graph);
+
+	}
+	
+}

--- a/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
@@ -19,69 +19,63 @@ import org.archive.wayback.util.partition.Partitioner;
 * effort to integrate Stanford version with existing core code.
 */
 public class InteractiveToolBarData extends ToolBarData {
-	
-	private static final PartitionSize daySize = Partitioner.daySize;
 
-	private static final CaptureSearchResultPartitionMap dayMap = 
-			new CaptureSearchResultPartitionMap();
-	private static final Partitioner<CaptureSearchResult> dayPartitioner = 
-			new Partitioner<CaptureSearchResult>(dayMap);
-	
-	public List<Partition<CaptureSearchResult>> dayPartitions;
+  private static final PartitionSize daySize = Partitioner.daySize;
 
-	public String firstResultReplayUrl;
-	public String lastResultReplayUrl;
-	
-	public InteractiveToolBarData(UIResults uiResults) {
-		//super(uiResults);
-		this.uiResults = uiResults;
-		fmt = uiResults.getWbRequest().getFormatter();
-		results = uiResults.getCaptureResults();
-		curResult = uiResults.getResult();
-		findRelativeLinks();
+  private static final CaptureSearchResultPartitionMap dayMap = new CaptureSearchResultPartitionMap();
+  private static final Partitioner<CaptureSearchResult> dayPartitioner = new Partitioner<CaptureSearchResult>(dayMap);
 
-		Date firstDate = uiResults.getWbRequest().getStartDate();
-		Date lastDate = uiResults.getWbRequest().getEndDate();
-		yearPartitions = yearPartitioner.getRange(yearSize,firstDate,lastDate);
-	
-		Date firstYearDate = yearPartitions.get(0).getStart();
-		Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
-		dayPartitions =
-				dayPartitioner.getRange(daySize,firstYearDate,lastYearDate);
-		
-		Iterator<CaptureSearchResult> it = results.iterator();
-		
-		firstResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getFirst()));
-		lastResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getLast()));
-		
-		dayPartitioner.populate(dayPartitions,it);
-		yearPartitioner.populate(yearPartitions,dayPartitions.iterator());
-	}
-	
-	/**
-	 * @param formatKey String template for format Dates
-	 * @param width pixel width of resulting graph
-	 * @param height pixel height of resulting graph
-	 * @return String argument which will generate a graph for the results
-	 */
-	public String computeGraphString(String formatKey, int width, int height) {
-		Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions,
-				fmt,formatKey,width,height);
-		
-		RegionGraphElement rge[] = graph.getRegions();
-		RegionData data[] = new RegionData[rge.length];
-		for(int i = 0; i < data.length; i++) {
-			data[i] = rge[i].getData();
-			
-			for(int j=0; j<data[i].getValues().length;j++){
-			//	System.out.print(data[i].getValues()[j]+"");
-			}
-			
-			//System.out.println();
-		}
-		
-		return GraphEncoder.encode(graph);
+  public List<Partition<CaptureSearchResult>> dayPartitions;
 
-	}
-	
+  public String firstResultReplayUrl;
+  public String lastResultReplayUrl;
+
+  public InteractiveToolBarData(UIResults uiResults) {
+    //super(uiResults);
+    this.uiResults = uiResults;
+    fmt = uiResults.getWbRequest().getFormatter();
+    results = uiResults.getCaptureResults();
+    curResult = uiResults.getResult();
+    findRelativeLinks();
+
+    Date firstDate = uiResults.getWbRequest().getStartDate();
+    Date lastDate = uiResults.getWbRequest().getEndDate();
+    yearPartitions = yearPartitioner.getRange(yearSize, firstDate, lastDate);
+
+    Date firstYearDate = yearPartitions.get(0).getStart();
+    Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
+    dayPartitions = dayPartitioner.getRange(daySize, firstYearDate, lastYearDate);
+
+    Iterator<CaptureSearchResult> it = results.iterator();
+
+    firstResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getFirst()));
+    lastResultReplayUrl = fmt.escapeHtml(uiResults.resultToReplayUrl(results.getResults().getLast()));
+
+    dayPartitioner.populate(dayPartitions, it);
+    yearPartitioner.populate(yearPartitions, dayPartitions.iterator());
+  }
+
+  /**
+   * @param formatKey String template for format Dates
+   * @param width pixel width of resulting graph
+   * @param height pixel height of resulting graph
+   * @return String argument which will generate a graph for the results
+   */
+  public String computeGraphString(String formatKey, int width, int height) {
+    Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions, fmt, formatKey, width,height);
+
+    RegionGraphElement rge[] = graph.getRegions();
+    RegionData data[] = new RegionData[rge.length];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = rge[i].getData();
+
+      for (int j=0; j<data[i].getValues().length;j++) {
+        //System.out.print(data[i].getValues()[j]+"");
+      }
+      //System.out.println();
+    }
+
+    return GraphEncoder.encode(graph);
+  }
+
 }

--- a/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/InteractiveToolBarData.java
@@ -31,11 +31,10 @@ public class InteractiveToolBarData extends ToolBarData {
   public String lastResultReplayUrl;
 
   public InteractiveToolBarData(UIResults uiResults) {
-    //super(uiResults);
     this.uiResults = uiResults;
     fmt = uiResults.getWbRequest().getFormatter();
     results = uiResults.getCaptureResults();
-    curResult = uiResults.getResult();
+    // curResult = uiResults.getResult();
     findRelativeLinks();
 
     Date firstDate = uiResults.getWbRequest().getStartDate();
@@ -68,11 +67,6 @@ public class InteractiveToolBarData extends ToolBarData {
     RegionData data[] = new RegionData[rge.length];
     for (int i = 0; i < data.length; i++) {
       data[i] = rge[i].getData();
-
-      for (int j=0; j<data[i].getValues().length;j++) {
-        //System.out.print(data[i].getValues()[j]+"");
-      }
-      //System.out.println();
     }
 
     return GraphEncoder.encode(graph);

--- a/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
@@ -1,0 +1,220 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual 
+ *  contributors. 
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.archive.wayback.partition;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.CaptureSearchResults;
+import org.archive.wayback.core.UIResults;
+import org.archive.wayback.util.StringFormatter;
+import org.archive.wayback.util.graph.Graph;
+import org.archive.wayback.util.graph.GraphEncoder;
+import org.archive.wayback.util.partition.Partition;
+import org.archive.wayback.util.partition.PartitionSize;
+import org.archive.wayback.util.partition.Partitioner;
+
+
+/**
+ * @author brad
+ *
+ */
+public class ToolBarData {
+	
+	private UIResults uiResults;
+	private StringFormatter fmt;
+	
+	/** Latest Result one year before current, or null */
+	public CaptureSearchResult yearPrevResult;
+	/** Latest Result one month before current, or null */
+	public CaptureSearchResult monthPrevResult;
+	/** Latest Result before current, or null */
+	public CaptureSearchResult prevResult;
+	/** Earliest Result after current, or null */
+	public CaptureSearchResult nextResult;
+	/** Earliest Result one month after current, or null */
+	public CaptureSearchResult monthNextResult;
+	/** Earliest Result one year after current, or null */
+	public CaptureSearchResult yearNextResult;
+
+	/** current result being shown */
+	public CaptureSearchResult curResult;
+	/** the CaptureSearchResults object from the ResourceIndex. */
+	public CaptureSearchResults results;
+	/** List<Part<Part<CResult>>> for years*/
+	public List<Partition<Partition<CaptureSearchResult>>> yearPartitions;
+	/** List<Part<CResult>> for months*/
+	public List<Partition<CaptureSearchResult>> monthPartitions;
+	
+	private static final PartitionSize yearSize = Partitioner.yearSize;
+	private static final PartitionSize monthSize = Partitioner.monthSize;
+
+	private static final CaptureSearchResultPartitionMap monthMap = 
+		new CaptureSearchResultPartitionMap();
+	private static final PartitionPartitionMap yearMap = 
+		new PartitionPartitionMap();
+	
+	private static final Partitioner<Partition<CaptureSearchResult>> 
+		yearPartitioner = 
+			new Partitioner<Partition<CaptureSearchResult>>(yearMap);
+	private static final Partitioner<CaptureSearchResult> monthPartitioner = 
+		new Partitioner<CaptureSearchResult>(monthMap);
+
+	/**
+	 * @param uiResults the UIResults holding replay info
+	 */
+	public ToolBarData(UIResults uiResults) {
+		this.uiResults = uiResults;
+		fmt = uiResults.getWbRequest().getFormatter();
+		results = uiResults.getCaptureResults();
+		curResult = uiResults.getResult();
+		findRelativeLinks();
+		Date firstDate = uiResults.getWbRequest().getStartDate();
+		Date lastDate = uiResults.getWbRequest().getEndDate();
+
+		yearPartitions = yearPartitioner.getRange(yearSize,firstDate,lastDate);
+
+		Date firstYearDate = yearPartitions.get(0).getStart();
+		Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
+
+		monthPartitions =
+			monthPartitioner.getRange(monthSize,firstYearDate,lastYearDate);
+
+		Iterator<CaptureSearchResult> it = results.iterator();
+
+		monthPartitioner.populate(monthPartitions,it);
+		yearPartitioner.populate(yearPartitions,monthPartitions.iterator());
+	
+	}
+
+	/**
+	 * @param formatKey String template for format Dates
+	 * @param width pixel width of resulting graph
+	 * @param height pixel height of resulting graph
+	 * @return String argument which will generate a graph for the results
+	 */
+	public String computeGraphString(String formatKey, int width, int height) {
+		Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions,
+				fmt,formatKey,width,height);
+		return GraphEncoder.encode(graph);
+
+	}
+	/**
+	 * @param result Restul to draw replay URL for
+	 * @return String absolute URL that will replay result
+	 */
+	public String makeReplayURL(CaptureSearchResult result) {
+		return fmt.escapeHtml(uiResults.getURIConverter().makeReplayURI(
+				result.getCaptureTimestamp(), result.getOriginalUrl()));
+	}
+	
+	/**
+	 * @return the total number of results
+	 */
+	public long getResultCount() {
+		return uiResults.getCaptureResults().getReturnedCount();
+	}
+	/**
+	 * @return the Date of the first capture in the result set
+	 */
+	public Date getFirstResultDate() {
+		return uiResults.getCaptureResults().getFirstResultDate();
+	}
+	/**
+	 * @return the Date of the last capture in the result set
+	 */
+	public Date getLastResultDate() {
+		return uiResults.getCaptureResults().getLastResultDate();
+	}
+	
+
+	private static Date addDateField(Date date, int field, int amt) {
+		Calendar c = PartitionsToGraph.getUTCCalendar();
+		c.setTime(date);
+		c.add(field, amt);
+		return c.getTime();
+	}	
+	/**
+	 * Increment a Date object by +/- some years
+	 * @param date Date to +/- some years from
+	 * @param amt number of years to add/remove
+	 * @return new Date object offset by the indicated years
+	 */
+	public static Date addYear(Date date, int amt) {
+		return addDateField(date,Calendar.YEAR,amt);
+	}
+	/**
+	 * Increment a Date object by +/- some months
+	 * @param date Date to +/- some months from
+	 * @param amt number of months to add/remove
+	 * @return new Date object offset by the indicated months
+	 */
+	public static Date addMonth(Date date, int amt) {
+		return addDateField(date,Calendar.MONTH,amt);
+	}
+	/**
+	 * Increment a Date object by +/- some days
+	 * @param date Date to +/- some days from
+	 * @param amt number of days to add/remove
+	 * @return new Date object offset by the indicated days
+	 */
+	public static Date addDay(Date date, int amt) {
+		return addDateField(date,Calendar.DATE,amt);
+	}
+	private void findRelativeLinks() {
+		Date cur = curResult.getCaptureDate();
+		
+		Date minYear = addYear(cur,-1);
+		Date minMonth = addMonth(cur,-1);
+		Date addYear = addYear(cur,1);
+		Date addMonth = addMonth(cur,1);
+		Iterator<CaptureSearchResult> itr = results.iterator();
+		while(itr.hasNext()) {
+			CaptureSearchResult result = itr.next();
+			Date d = result.getCaptureDate();
+			if(d.compareTo(cur) < 0) {
+				prevResult = result;
+				if(d.compareTo(minMonth) < 0) {
+					monthPrevResult = result;
+				}
+				if(d.compareTo(minYear) < 0 ) {
+					yearPrevResult = result;
+				}
+			} else if(d.compareTo(cur) > 0) {
+				if(nextResult == null) {
+					nextResult = result;
+				}
+				if(d.compareTo(addYear) > 0) {
+					if(yearNextResult == null) {
+						yearNextResult = result;
+					}
+				}
+				if(d.compareTo(addMonth) > 0) {
+					if(monthNextResult == null) {
+						monthNextResult = result;
+					}
+				}
+			}
+		}
+	}
+}

--- a/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
@@ -40,8 +40,8 @@ import org.archive.wayback.util.partition.Partitioner;
  */
 public class ToolBarData {
 
-  private UIResults uiResults;
-  private StringFormatter fmt;
+  protected UIResults uiResults;
+  protected StringFormatter fmt;
 
   /** Latest Result one year before current, or null */
   public CaptureSearchResult yearPrevResult;
@@ -65,15 +65,15 @@ public class ToolBarData {
   /** List<Part<CResult>> for months*/
   public List<Partition<CaptureSearchResult>> monthPartitions;
 
-  private static final PartitionSize yearSize = Partitioner.yearSize;
-  private static final PartitionSize monthSize = Partitioner.monthSize;
+  protected static final PartitionSize yearSize = Partitioner.yearSize;
+  protected static final PartitionSize monthSize = Partitioner.monthSize;
 
-  private static final CaptureSearchResultPartitionMap monthMap = new CaptureSearchResultPartitionMap();
-  private static final PartitionPartitionMap yearMap = new PartitionPartitionMap();
+  protected static final CaptureSearchResultPartitionMap monthMap = new CaptureSearchResultPartitionMap();
+  protected static final PartitionPartitionMap yearMap = new PartitionPartitionMap();
 
-  private static final Partitioner<Partition<CaptureSearchResult>> yearPartitioner =
+  protected static final Partitioner<Partition<CaptureSearchResult>> yearPartitioner =
     new Partitioner<Partition<CaptureSearchResult>>(yearMap);
-  private static final Partitioner<CaptureSearchResult> monthPartitioner =
+  protected static final Partitioner<CaptureSearchResult> monthPartitioner =
     new Partitioner<CaptureSearchResult>(monthMap);
 
   /**
@@ -99,6 +99,12 @@ public class ToolBarData {
 
     monthPartitioner.populate(monthPartitions, it);
     yearPartitioner.populate(yearPartitions, monthPartitions.iterator());
+  }
+
+  /**
+   * Implicit constructor to keep the child class (InteractiveToolBarData) clean
+   */
+  protected ToolBarData() {
   }
 
   /**
@@ -178,7 +184,7 @@ public class ToolBarData {
     return addDateField(date, Calendar.DATE, amt);
   }
 
-  private void findRelativeLinks() {
+  protected void findRelativeLinks() {
     Date cur = curResult.getCaptureDate();
     Date minYear = addYear(cur, -1);
     Date minMonth = addMonth(cur, -1);

--- a/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
+++ b/wayback-core/src/main/java/org/archive/wayback/partition/ToolBarData.java
@@ -2,8 +2,8 @@
  *  This file is part of the Wayback archival access software
  *   (http://archive-access.sourceforge.net/projects/wayback/).
  *
- *  Licensed to the Internet Archive (IA) by one or more individual 
- *  contributors. 
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
  *
  *  The IA licenses this file to You under the Apache License, Version 2.0
  *  (the "License"); you may not use this file except in compliance with
@@ -34,187 +34,183 @@ import org.archive.wayback.util.partition.Partition;
 import org.archive.wayback.util.partition.PartitionSize;
 import org.archive.wayback.util.partition.Partitioner;
 
-
 /**
  * @author brad
  *
  */
 public class ToolBarData {
-	
-	private UIResults uiResults;
-	private StringFormatter fmt;
-	
-	/** Latest Result one year before current, or null */
-	public CaptureSearchResult yearPrevResult;
-	/** Latest Result one month before current, or null */
-	public CaptureSearchResult monthPrevResult;
-	/** Latest Result before current, or null */
-	public CaptureSearchResult prevResult;
-	/** Earliest Result after current, or null */
-	public CaptureSearchResult nextResult;
-	/** Earliest Result one month after current, or null */
-	public CaptureSearchResult monthNextResult;
-	/** Earliest Result one year after current, or null */
-	public CaptureSearchResult yearNextResult;
 
-	/** current result being shown */
-	public CaptureSearchResult curResult;
-	/** the CaptureSearchResults object from the ResourceIndex. */
-	public CaptureSearchResults results;
-	/** List<Part<Part<CResult>>> for years*/
-	public List<Partition<Partition<CaptureSearchResult>>> yearPartitions;
-	/** List<Part<CResult>> for months*/
-	public List<Partition<CaptureSearchResult>> monthPartitions;
-	
-	private static final PartitionSize yearSize = Partitioner.yearSize;
-	private static final PartitionSize monthSize = Partitioner.monthSize;
+  private UIResults uiResults;
+  private StringFormatter fmt;
 
-	private static final CaptureSearchResultPartitionMap monthMap = 
-		new CaptureSearchResultPartitionMap();
-	private static final PartitionPartitionMap yearMap = 
-		new PartitionPartitionMap();
-	
-	private static final Partitioner<Partition<CaptureSearchResult>> 
-		yearPartitioner = 
-			new Partitioner<Partition<CaptureSearchResult>>(yearMap);
-	private static final Partitioner<CaptureSearchResult> monthPartitioner = 
-		new Partitioner<CaptureSearchResult>(monthMap);
+  /** Latest Result one year before current, or null */
+  public CaptureSearchResult yearPrevResult;
+  /** Latest Result one month before current, or null */
+  public CaptureSearchResult monthPrevResult;
+  /** Latest Result before current, or null */
+  public CaptureSearchResult prevResult;
+  /** Earliest Result after current, or null */
+  public CaptureSearchResult nextResult;
+  /** Earliest Result one month after current, or null */
+  public CaptureSearchResult monthNextResult;
+  /** Earliest Result one year after current, or null */
+  public CaptureSearchResult yearNextResult;
 
-	/**
-	 * @param uiResults the UIResults holding replay info
-	 */
-	public ToolBarData(UIResults uiResults) {
-		this.uiResults = uiResults;
-		fmt = uiResults.getWbRequest().getFormatter();
-		results = uiResults.getCaptureResults();
-		curResult = uiResults.getResult();
-		findRelativeLinks();
-		Date firstDate = uiResults.getWbRequest().getStartDate();
-		Date lastDate = uiResults.getWbRequest().getEndDate();
+  /** current result being shown */
+  public CaptureSearchResult curResult;
+  /** the CaptureSearchResults object from the ResourceIndex. */
+  public CaptureSearchResults results;
+  /** List<Part<Part<CResult>>> for years*/
+  public List<Partition<Partition<CaptureSearchResult>>> yearPartitions;
+  /** List<Part<CResult>> for months*/
+  public List<Partition<CaptureSearchResult>> monthPartitions;
 
-		yearPartitions = yearPartitioner.getRange(yearSize,firstDate,lastDate);
+  private static final PartitionSize yearSize = Partitioner.yearSize;
+  private static final PartitionSize monthSize = Partitioner.monthSize;
 
-		Date firstYearDate = yearPartitions.get(0).getStart();
-		Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
+  private static final CaptureSearchResultPartitionMap monthMap = new CaptureSearchResultPartitionMap();
+  private static final PartitionPartitionMap yearMap = new PartitionPartitionMap();
 
-		monthPartitions =
-			monthPartitioner.getRange(monthSize,firstYearDate,lastYearDate);
+  private static final Partitioner<Partition<CaptureSearchResult>> yearPartitioner =
+    new Partitioner<Partition<CaptureSearchResult>>(yearMap);
+  private static final Partitioner<CaptureSearchResult> monthPartitioner =
+    new Partitioner<CaptureSearchResult>(monthMap);
 
-		Iterator<CaptureSearchResult> it = results.iterator();
+  /**
+   * @param uiResults the UIResults holding replay info
+   */
+  public ToolBarData(UIResults uiResults) {
+    this.uiResults = uiResults;
+    fmt = uiResults.getWbRequest().getFormatter();
+    results = uiResults.getCaptureResults();
+    curResult = uiResults.getResult();
+    findRelativeLinks();
+    Date firstDate = uiResults.getWbRequest().getStartDate();
+    Date lastDate = uiResults.getWbRequest().getEndDate();
 
-		monthPartitioner.populate(monthPartitions,it);
-		yearPartitioner.populate(yearPartitions,monthPartitions.iterator());
-	
-	}
+    yearPartitions = yearPartitioner.getRange(yearSize, firstDate, lastDate);
 
-	/**
-	 * @param formatKey String template for format Dates
-	 * @param width pixel width of resulting graph
-	 * @param height pixel height of resulting graph
-	 * @return String argument which will generate a graph for the results
-	 */
-	public String computeGraphString(String formatKey, int width, int height) {
-		Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions,
-				fmt,formatKey,width,height);
-		return GraphEncoder.encode(graph);
+    Date firstYearDate = yearPartitions.get(0).getStart();
+    Date lastYearDate = yearPartitions.get(yearPartitions.size()-1).getEnd();
 
-	}
-	/**
-	 * @param result Restul to draw replay URL for
-	 * @return String absolute URL that will replay result
-	 */
-	public String makeReplayURL(CaptureSearchResult result) {
-		return fmt.escapeHtml(uiResults.getURIConverter().makeReplayURI(
-				result.getCaptureTimestamp(), result.getOriginalUrl()));
-	}
-	
-	/**
-	 * @return the total number of results
-	 */
-	public long getResultCount() {
-		return uiResults.getCaptureResults().getReturnedCount();
-	}
-	/**
-	 * @return the Date of the first capture in the result set
-	 */
-	public Date getFirstResultDate() {
-		return uiResults.getCaptureResults().getFirstResultDate();
-	}
-	/**
-	 * @return the Date of the last capture in the result set
-	 */
-	public Date getLastResultDate() {
-		return uiResults.getCaptureResults().getLastResultDate();
-	}
-	
+    monthPartitions = monthPartitioner.getRange(monthSize, firstYearDate, lastYearDate);
 
-	private static Date addDateField(Date date, int field, int amt) {
-		Calendar c = PartitionsToGraph.getUTCCalendar();
-		c.setTime(date);
-		c.add(field, amt);
-		return c.getTime();
-	}	
-	/**
-	 * Increment a Date object by +/- some years
-	 * @param date Date to +/- some years from
-	 * @param amt number of years to add/remove
-	 * @return new Date object offset by the indicated years
-	 */
-	public static Date addYear(Date date, int amt) {
-		return addDateField(date,Calendar.YEAR,amt);
-	}
-	/**
-	 * Increment a Date object by +/- some months
-	 * @param date Date to +/- some months from
-	 * @param amt number of months to add/remove
-	 * @return new Date object offset by the indicated months
-	 */
-	public static Date addMonth(Date date, int amt) {
-		return addDateField(date,Calendar.MONTH,amt);
-	}
-	/**
-	 * Increment a Date object by +/- some days
-	 * @param date Date to +/- some days from
-	 * @param amt number of days to add/remove
-	 * @return new Date object offset by the indicated days
-	 */
-	public static Date addDay(Date date, int amt) {
-		return addDateField(date,Calendar.DATE,amt);
-	}
-	private void findRelativeLinks() {
-		Date cur = curResult.getCaptureDate();
-		
-		Date minYear = addYear(cur,-1);
-		Date minMonth = addMonth(cur,-1);
-		Date addYear = addYear(cur,1);
-		Date addMonth = addMonth(cur,1);
-		Iterator<CaptureSearchResult> itr = results.iterator();
-		while(itr.hasNext()) {
-			CaptureSearchResult result = itr.next();
-			Date d = result.getCaptureDate();
-			if(d.compareTo(cur) < 0) {
-				prevResult = result;
-				if(d.compareTo(minMonth) < 0) {
-					monthPrevResult = result;
-				}
-				if(d.compareTo(minYear) < 0 ) {
-					yearPrevResult = result;
-				}
-			} else if(d.compareTo(cur) > 0) {
-				if(nextResult == null) {
-					nextResult = result;
-				}
-				if(d.compareTo(addYear) > 0) {
-					if(yearNextResult == null) {
-						yearNextResult = result;
-					}
-				}
-				if(d.compareTo(addMonth) > 0) {
-					if(monthNextResult == null) {
-						monthNextResult = result;
-					}
-				}
-			}
-		}
-	}
+    Iterator<CaptureSearchResult> it = results.iterator();
+
+    monthPartitioner.populate(monthPartitions, it);
+    yearPartitioner.populate(yearPartitions, monthPartitions.iterator());
+  }
+
+  /**
+   * @param formatKey String template for format Dates
+   * @param width pixel width of resulting graph
+   * @param height pixel height of resulting graph
+   * @return String argument which will generate a graph for the results
+   */
+  public String computeGraphString(String formatKey, int width, int height) {
+    Graph graph = PartitionsToGraph.partsOfPartsToGraph(yearPartitions, fmt, formatKey, width, height);
+    return GraphEncoder.encode(graph);
+  }
+
+  /**
+   * @param result Restul to draw replay URL for
+   * @return String absolute URL that will replay result
+   */
+  public String makeReplayURL(CaptureSearchResult result) {
+    return fmt.escapeHtml(uiResults.getURIConverter().makeReplayURI(result.getCaptureTimestamp(), result.getOriginalUrl()));
+  }
+
+  /**
+   * @return the total number of results
+   */
+  public long getResultCount() {
+    return uiResults.getCaptureResults().getReturnedCount();
+  }
+
+  /**
+   * @return the Date of the first capture in the result set
+   */
+  public Date getFirstResultDate() {
+    return uiResults.getCaptureResults().getFirstResultDate();
+  }
+
+  /**
+   * @return the Date of the last capture in the result set
+   */
+  public Date getLastResultDate() {
+    return uiResults.getCaptureResults().getLastResultDate();
+  }
+
+  private static Date addDateField(Date date, int field, int amt) {
+    Calendar c = PartitionsToGraph.getUTCCalendar();
+    c.setTime(date);
+    c.add(field, amt);
+    return c.getTime();
+  }
+
+  /**
+   * Increment a Date object by +/- some years
+   * @param date Date to +/- some years from
+   * @param amt number of years to add/remove
+   * @return new Date object offset by the indicated years
+   */
+  public static Date addYear(Date date, int amt) {
+    return addDateField(date, Calendar.YEAR, amt);
+  }
+
+  /**
+   * Increment a Date object by +/- some months
+   * @param date Date to +/- some months from
+   * @param amt number of months to add/remove
+   * @return new Date object offset by the indicated months
+   */
+  public static Date addMonth(Date date, int amt) {
+    return addDateField(date, Calendar.MONTH, amt);
+  }
+
+  /**
+   * Increment a Date object by +/- some days
+   * @param date Date to +/- some days from
+   * @param amt number of days to add/remove
+   * @return new Date object offset by the indicated days
+   */
+  public static Date addDay(Date date, int amt) {
+    return addDateField(date, Calendar.DATE, amt);
+  }
+
+  private void findRelativeLinks() {
+    Date cur = curResult.getCaptureDate();
+    Date minYear = addYear(cur, -1);
+    Date minMonth = addMonth(cur, -1);
+    Date addYear = addYear(cur, 1);
+    Date addMonth = addMonth(cur, 1);
+    Iterator <CaptureSearchResult> itr = results.iterator();
+    while(itr.hasNext()) {
+      CaptureSearchResult result = itr.next();
+      Date d = result.getCaptureDate();
+      if (d.compareTo(cur) < 0) {
+        prevResult = result;
+        if (d.compareTo(minMonth) < 0) {
+          monthPrevResult = result;
+        }
+        if (d.compareTo(minYear) < 0 ) {
+          yearPrevResult = result;
+        }
+      } else if (d.compareTo(cur) > 0) {
+        if (nextResult == null) {
+          nextResult = result;
+        }
+        if (d.compareTo(addYear) > 0) {
+          if (yearNextResult == null) {
+            yearNextResult = result;
+          }
+        }
+        if (d.compareTo(addMonth) > 0) {
+          if (monthNextResult == null) {
+            monthNextResult = result;
+          }
+        }
+      }
+    }
+  }
 }

--- a/wayback-core/src/test/java/org/archive/io/warc/TestWARCReader.java
+++ b/wayback-core/src/test/java/org/archive/io/warc/TestWARCReader.java
@@ -1,0 +1,110 @@
+package org.archive.io.warc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.text.ParseException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.archive.io.ArchiveReader;
+import org.archive.io.ArchiveRecord;
+import org.archive.util.anvl.ANVLRecord;
+import org.archive.util.anvl.Element;
+
+import com.google.common.io.CountingInputStream;
+
+/**
+ * Fixture WARCReader.
+ * <p>It works as ArchiveReader reading from WARC file with just one
+ * WARC record at offset 0 (there's no "warcinfo" record).</p>
+ * <p>Content of the record is customized through {@link WARCRecordInfo}.
+ * ({@link TestWARCRecordInfo} offers commonly-used default values and convenient factory
+ * methods.</p>
+ * <p>Typical test code would be:</p>
+ * <pre>
+ * String payload = "hogehogehogehogehoge";
+ * WARCRecordInfo recinfo = TestWARCRecordInfo.createHttpResponse(payload);
+ * TestWARCReader ar = new TestWARCReader(recinfo);
+ * WARCRecord rec = (WARCRecord)ar.get(0);
+ * </pre>
+ * 
+ * @contributor kenji
+ *
+ */
+public class TestWARCReader extends ArchiveReader {
+    public static final String CRLF = "\r\n";
+    
+    public TestWARCReader(InputStream is) {
+        setIn(is);
+    }
+    public TestWARCReader(WARCRecordInfo recinfo) throws IOException {
+        // not clearly stated, but ArchiveReader expects CountingInputStream.
+        setIn(new CountingInputStream(TestWARCReader.buildRecordContent(recinfo)));
+    }
+    
+    @Override
+    public WARCRecord get(long offset) throws IOException {
+        return (WARCRecord)super.get(offset);
+    }
+    @Override
+    protected WARCRecord createArchiveRecord(InputStream is, long offset)
+            throws IOException {
+        return (WARCRecord)currentRecord(new WARCRecord(is, "<identifier>", offset));
+    }
+    @Override
+    protected void gotoEOR(ArchiveRecord record) throws IOException {
+    }
+    @Override
+    public String getFileExtension() {
+        return "warc";
+    }
+    @Override
+    public String getDotFileExtension() {
+        return ".warc";
+    }
+    @Override
+    public void dump(boolean compress) throws IOException, ParseException {
+        // TODO Auto-generated method stub
+    }
+    @Override
+    public ArchiveReader getDeleteFileOnCloseReader(File f) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+    /**
+     * build minimal WARC record byte stream.
+     * @param recinfo WARCRecordInfo with record metadata and content
+     * @return InputStream reading from created record bits
+     * @throws IOException
+     */
+    public static InputStream buildRecordContent(WARCRecordInfo recinfo) throws IOException {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        Writer w = new OutputStreamWriter(buf);
+        w.write("WARC/1.0" + CRLF);
+        w.write("WARC-Type: " + recinfo.getType() + CRLF);
+        if (StringUtils.isNotEmpty(recinfo.getUrl())) {
+            w.write("WARC-Target-URI: " + recinfo.getUrl() + CRLF);
+        }
+        w.write("WARC-Date: " + recinfo.getCreate14DigitDate() + CRLF);
+        if (recinfo.getExtraHeaders() != null) {
+            ANVLRecord headers = recinfo.getExtraHeaders();
+            for (Element el : headers) {
+                w.write(el.getLabel() + ": " + el.getValue() + CRLF);
+            }
+        }
+        w.write("Content-Type: " + recinfo.getMimetype() + CRLF);
+        w.write("Content-Length: " + recinfo.getContentLength() + CRLF);
+        w.write(CRLF);
+        w.flush();
+        IOUtils.copy(recinfo.getContentStream(), buf);
+        buf.write((CRLF+CRLF).getBytes());
+        buf.close();
+        
+        return new ByteArrayInputStream(buf.toByteArray());
+    }        
+}

--- a/wayback-core/src/test/java/org/archive/io/warc/TestWARCRecordInfo.java
+++ b/wayback-core/src/test/java/org/archive/io/warc/TestWARCRecordInfo.java
@@ -1,0 +1,260 @@
+package org.archive.io.warc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.zip.GZIPOutputStream;
+
+import org.archive.format.ArchiveFileConstants;
+import org.archive.format.warc.WARCConstants;
+import org.archive.util.DateUtils;
+
+/**
+ * WARCRecordInfo with default values and convenience factory methods.
+ * 
+ * TODO: use existing well-tested HTTP library for generating HTTP content-block.
+ * 
+ * @see TestWARCReader
+ * @contributor kenji
+ * 
+ */
+public class TestWARCRecordInfo extends WARCRecordInfo implements WARCConstants, ArchiveFileConstants {
+
+    final static String REVISIT_WARC_PROFILE =
+            "http://netpreserve.org/warc/1.0/revisit/identical-payload-digest";
+    
+    public TestWARCRecordInfo(byte[] content) {
+        this.type = WARCRecordType.response;
+        this.url = "http://test.example.com/";
+        this.mimetype = "application/http; msgtype=response";
+        try {
+            this.recordId = new URI("uri:recordidentifier");
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException("unexpected error", ex);
+        }
+        this.contentStream = new ByteArrayInputStream(content);
+        this.contentLength = content.length;
+        // NB: create14DigitDate must be in ISOZ format (name "14DigitDate" is confusing)
+        this.create14DigitDate = DateUtils.getLog14Date();
+    }
+    
+    /**
+     * translates DT14 (YYYYmmddHHMMSS) to ISOZ format used in WARC-Date header.
+     * @param dt14
+     * @return ISOZ (YYYY-mm-ddTHH:MM:SSZ)
+     * @exception IOException dt14 is in bad format (wrapping ParseException to simply error handling)
+     */
+    public static String dt14ToISOZ(String dt14) throws IOException {
+        try {
+            Date date = DateUtils.parse14DigitDate(dt14);
+            return DateUtils.getLog14Date(date);
+        } catch (ParseException ex) {
+            throw new IOException("invalid DT14 " + dt14, ex);
+        }
+    }
+    /**
+     * utility method for updating create14DigitDate from DT14.
+     * @param dt14 DT14 (YYYYmmddHHMMSS)
+     * @throws IOException dt14 is in bad format.
+     */
+    public void setCreate14DigitDateFromDT14(String dt14) throws IOException {
+        create14DigitDate = dt14ToISOZ(dt14);
+    }
+    
+    // factory methods
+    
+    /**
+     * return TestWARCRecordInfo for HTTP Response with entity {@code payload}.
+     * Content-Type is {@code text/plain}, and {@code payload} is encoded in UTF-8.
+     * @param payload
+     * @return
+     * @throws IOException
+     */
+    public static TestWARCRecordInfo createHttpResponse(String payload) 
+            throws IOException {
+        return new TestWARCRecordInfo(buildHttpResponseBlock("text/plain", payload.getBytes("UTF-8")));
+    }
+    /**
+     * return TestWARCRecordInfo for HTTP Response with entity {@code payload}.
+     * @param ctype Content-Type value
+     * @param payloadBytes payload bytes
+     * @return WARCRecordInfo with default values set to key properties.
+     * @throws IOException
+     */
+    public static TestWARCRecordInfo createHttpResponse(String ctype, byte[] payloadBytes)
+            throws IOException {
+        return new TestWARCRecordInfo(buildHttpResponseBlock(ctype, payloadBytes));
+    }
+    public static TestWARCRecordInfo createCompressedHttpResponse(String ctype,
+            byte[] payloadBytes) throws IOException {
+        return new TestWARCRecordInfo(buildCompressedHttpResponseBlock(ctype, payloadBytes));
+    }
+    public static TestWARCRecordInfo createRevisitHttpResponse(String ctype, int len, boolean withHeader)
+            throws IOException {
+        return createRevisitHttpResponse(ctype, len, withHeader, false);
+    }
+    public static TestWARCRecordInfo createRevisitHttpResponse(String ctype, int len, boolean withHeader, boolean gzipContent)
+            throws IOException {
+        TestWARCRecordInfo recinfo = new TestWARCRecordInfo(buildRevisitHttpResponseBlock(ctype, len, withHeader, gzipContent));
+        recinfo.setType(WARCRecordType.revisit);
+        recinfo.addExtraHeader("WARC-Truncated", "length");
+        recinfo.addExtraHeader("WARC-Profile", REVISIT_WARC_PROFILE);
+        return recinfo;
+        
+    }
+    public static TestWARCRecordInfo createRevisitHttpResponse(String ctype, int len)
+            throws IOException {
+        return createRevisitHttpResponse(ctype, len, true);
+    }
+    
+    
+    public static byte[] buildHttpResponseBlock(String payload) throws IOException {
+        return buildHttpResponseBlock("text/plain", payload.getBytes());
+    }
+
+    /**
+     * short cut for generating "200 OK" HTTP response content-block.
+     * @param ctype HTTP Content-Type, such as {@code "text/plain"}, {@code "image/gif"}
+     * @param payloadBytes payload bytes
+     * @return content-block bytes with HTTP status line, HTTP headers and payload.
+     * @throws IOException
+     */
+    public static byte[] buildHttpResponseBlock(String ctype, byte[] payloadBytes) throws IOException {
+        return buildHttpResponseBlock("200 OK", ctype, payloadBytes);
+    }
+    
+    private static void writeChunked(OutputStream out, byte[] data) throws IOException {
+        int s = 0;
+        while (s < data.length) {
+            int n = data.length - s;
+            if (n > 0x1000) n = 0x1000;
+            out.write(String.format("%x" + CRLF, n).getBytes("UTF-8"));
+            out.write(data, s, n);
+            out.write(CRLF.getBytes("UTF-8"));
+            s += n;
+        }
+        out.write(("0" + CRLF + CRLF).getBytes("UTF-8"));
+    }
+    /**
+     * return content-block bytes for HTTP response.
+     * @param status HTTP status code and status text separated by a space. ex. {@code "200 OK"}.
+     * @param ctype HTTP Content-Type
+     * @param payloadBytes payload bytes
+     * @param chunked if true, use chunked transfer-encoding
+     * @return content-block bytes with HTTP status line, HTTP headers and payload.
+     * @throws IOException
+     */
+    public static byte[] buildHttpResponseBlock(String status, String ctype, byte[] payloadBytes, boolean chunked)
+            throws IOException {
+        ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+        Writer bw = new OutputStreamWriter(blockbuf);
+        bw.write("HTTP/1.0 " + status + CRLF);
+        if (chunked) {
+            bw.write("Transfer-Encoding: chunked" + CRLF);
+        } else {
+            bw.write("Content-Length: " + payloadBytes.length + CRLF);
+        }
+        bw.write("Content-Type: " + ctype + CRLF);
+        bw.write(CRLF);
+        bw.flush();
+        if (chunked) {
+            writeChunked(blockbuf, payloadBytes);
+        } else {
+            blockbuf.write(payloadBytes);
+        }
+        bw.close();
+        return blockbuf.toByteArray();
+    }
+    public static byte[] buildHttpResponseBlock(String status, String ctype, byte[] payloadBytes) throws IOException {
+        return buildHttpResponseBlock(status, ctype, payloadBytes, false);
+    }
+    
+    public static byte[] buildHttpRedirectResponseBlock(String location) throws IOException {
+        ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+        Writer bw = new OutputStreamWriter(blockbuf);
+        String status = "302 Moved Temporarily";
+        bw.write("HTTP/1.0 " + status + CRLF);
+        bw.write("Content-Length: " + 0 + CRLF);
+        bw.write("Content-Type: text/html" + CRLF);
+        bw.write("Location: " + location + CRLF);
+        bw.write(CRLF);
+        bw.close();
+        return blockbuf.toByteArray();
+    }
+    
+    public static byte[] buildCompressedHttpResponseBlock(String ctype,
+            byte[] payloadBytes, boolean chunked) throws IOException {
+        ByteArrayOutputStream gzippedPayloadBytes = new ByteArrayOutputStream();
+        GZIPOutputStream zout = new GZIPOutputStream(gzippedPayloadBytes);
+        zout.write(payloadBytes);
+        zout.close();
+        payloadBytes = gzippedPayloadBytes.toByteArray();
+        ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+        Writer bw = new OutputStreamWriter(blockbuf);
+        bw.write("HTTP/1.0 200 OK" + CRLF);
+        if (chunked) {
+            bw.write("Transfer-Encoding: chunked" + CRLF);
+        } else {
+            bw.write("Content-Length: " + payloadBytes.length + CRLF);
+        }
+        bw.write("Content-Type: " + ctype + CRLF);
+        bw.write("Content-Encoding: gzip" + CRLF);
+        bw.write(CRLF);
+        bw.flush();
+        if (chunked) {
+            writeChunked(blockbuf, payloadBytes);
+        } else {
+            blockbuf.write(payloadBytes);
+        }
+        bw.close();
+        return blockbuf.toByteArray();
+    }
+    public static byte[] buildCompressedHttpResponseBlock(String ctype, byte[] payloadBytes) throws IOException {
+        return buildCompressedHttpResponseBlock(ctype, payloadBytes, false);
+    }
+    
+    /**
+     * generates WARC content for new revisit record.
+     * @param ctype value for Content-Type
+     * @param len value for Content-Length
+     * @param withHeader include HTTP status line and headers.
+     *      passing false generates old-style revisit content block.
+     * @param gzipContent if true, block will have "Content-Encoding: gzip" header.
+     *      (this shall match the compress-ness of previous capture).
+     * @return record content as byte array
+     * @throws IOException
+     */
+    public static byte[] buildRevisitHttpResponseBlock(String ctype, int len,
+            boolean withHeader, boolean gzipContent) throws IOException {
+        ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+        Writer bw = new OutputStreamWriter(blockbuf);
+        if (withHeader) {
+            bw.write("HTTP/1.0 200 OK" + CRLF);
+            bw.write("Content-Length: " + len + CRLF);
+            bw.write("Content-Type: " + ctype + CRLF);
+            if (gzipContent)
+                bw.write("Content-Encoding: gzip" + CRLF);
+            bw.write(CRLF);
+            bw.flush();
+            bw.close();
+        }
+        return blockbuf.toByteArray();
+    }
+
+    // POPULAR PAYLOAD SAMPLES
+    
+    // ubiquitous 1-pixel transparent GIF, if you wonder.
+    public static final byte[] PAYLOAD_GIF = new byte[] {
+            71, 73, 70, 56, 57, 97, 1, 0, 1, 0, -128, 0, 0, -64, -64, -64,
+            0, 0, 0, 33, -7, 4, 1, 0, 0, 0, 0, 44, 0, 0, 0, 0,
+            1, 0, 1, 0, 0, 2, 2, 68, 1, 0, 59, 13, 10, 13, 10
+    };
+
+}

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.archive.wayback.archivalurl;
 
@@ -43,9 +43,9 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
     WaybackRequest wbRequest;
     CaptureSearchResult result;
     TestServletOutputStream servletOutput = new TestServletOutputStream();
-    
+
     ArchivalUrlSAXRewriteReplayRenderer cut;
-    
+
     public static class TestParseEventHandler implements ParseEventHandler {
         @Override
         public void handleParseStart(ParseContext context) {
@@ -62,7 +62,7 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         public void handleParseComplete(ParseContext context) {
         }
     }
-    
+
     /* (non-Javadoc)
      * @see junit.framework.TestCase#setUp()
      */
@@ -70,21 +70,21 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         super.setUp();
         RedirectRewritingHttpHeaderProcessor httpHeaderProcessor = new RedirectRewritingHttpHeaderProcessor();
         httpHeaderProcessor.setPrefix("X-Archive-Orig-");
-        
+
         cut = new ArchivalUrlSAXRewriteReplayRenderer(httpHeaderProcessor);
-        
+
         uriConverter = EasyMock.createMock(ResultURIConverter.class);
-        
+
         response = EasyMock.createMock(HttpServletResponse.class);
         EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
-        
+
         nodeHandler = EasyMock.createMock(ParseEventHandler.class);
         cut.setDelegator(nodeHandler);
-        
+
         wbRequest = new WaybackRequest();
         wbRequest.setFrameWrapperContext(false);
-        
-        // replace default CharsetDetector (StandardCharsetDetector) with a stub 
+
+        // replace default CharsetDetector (StandardCharsetDetector) with a stub
         // so as not to depend on its behavior.
         cut.setCharsetDetector(new CharsetDetector() {
             @Override
@@ -93,11 +93,11 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
                 return "UTF-8";
             }
         });
-        
+
         result = new CaptureSearchResult();
         result.setOriginalUrl("http://www.example.com/");
     }
-    
+
     public static Resource createTestHtmlResource(byte[] payloadBytes) throws IOException {
         WARCRecordInfo recinfo = TestWARCRecordInfo.createCompressedHttpResponse("text/html", payloadBytes);
         TestWARCReader ar = new TestWARCReader(recinfo);
@@ -115,14 +115,14 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         resource.parseHeaders();
         return resource;
     }
-    
+
     /**
      * test basic behavior with simple input.
      * expectations:
      * <ul>
      * <li>reads <em>decoded (uncompressed)</em> contents from archive record.</li>
      * <li>calls delegator.handleParseStart() and handleParseComplete() just once, respectively.</li>
-     * <li>calls HttpServletResponse.setHeader() for Content-Type, Content-Length and 
+     * <li>calls HttpServletResponse.setHeader() for Content-Type, Content-Length and
      *   {@link TextReplayRenderer#GUESSED_CHARSET_HEADER} (not configurable as with TextReplayRenderer
      *   subclasses.</li>
      * <li>calls HttpServletResponse.setCharsetEncoding() with value "utf-8"</li>
@@ -136,7 +136,7 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         String payload = "<HTML></HTML>\n";
         final byte[] payloadBytes = payload.getBytes("UTF-8");
         Resource payloadResource = createTestHtmlResource(payloadBytes);
-        
+
         Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
         Capture<Node> nodeCapture = new Capture<Node>();
         nodeHandler.handleParseStart(EasyMock.<ReplayParseContext>anyObject());
@@ -150,25 +150,26 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
         response.setHeader(TextReplayRenderer.GUESSED_CHARSET_HEADER, "UTF-8");
         response.setHeader("Content-Type", "text/html");
+        response.setHeader("X-UA-Compatible", "IE=edge");
         response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
         EasyMock.expectLastCall().anyTimes();
-        
+
         EasyMock.replay(nodeHandler, response, uriConverter);
-        
+
         cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
-        
+
         EasyMock.verify(nodeHandler, response, uriConverter);
-        
+
         // NOTE: this compares output of Node.toHtml() with the original input.
         // there's a good chance of Node.toHtml() producing different text than original HTML.
         String out = servletOutput.getString();
         assertEquals("servlet output", payload, out);
-        
+
         ReplayParseContext context = parseContextCapture.getValue();
         // testing indirectly because ReplayParseContext has no method returning baseUrl.
         assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
     }
-    
+
     /**
      * test revisit record (in new format with HTTP headers).
      * @throws Exception
@@ -193,28 +194,29 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
         response.setHeader(TextReplayRenderer.GUESSED_CHARSET_HEADER, "UTF-8");
         response.setHeader("Content-Type", "text/html");
+        response.setHeader("X-UA-Compatible", "IE=edge");
         response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
         EasyMock.expectLastCall().anyTimes();
-        
+
         EasyMock.replay(nodeHandler, response, uriConverter);
-        
+
         cut.renderResource(null, response, wbRequest, result, headerResource, payloadResource, uriConverter, null);
-        
+
         EasyMock.verify(nodeHandler, response, uriConverter);
-        
+
         // NOTE: this compares output of Node.toHtml() with the original input.
         // there's a good chance of Node.toHtml() producing different text than original HTML.
         String out = servletOutput.getString();
         assertEquals("servlet output", payload, out);
-        
+
         ReplayParseContext context = parseContextCapture.getValue();
         // testing indirectly because ReplayParseContext has no method returning baseUrl.
         assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
     }
-    
+
     // no test for old-style revisit record as headerResource, because it is caller's responsibility to
     // set headerResource = payloadResource in this case.
-    
+
 //    /**
 //     * test revisit record (in old format without HTTP headers).
 //     * @throws Exception
@@ -240,50 +242,50 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
 //        response.setHeader("Content-Type", "text/html");
 //        response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
 //        EasyMock.expectLastCall().anyTimes();
-//        
+//
 //        EasyMock.replay(nodeHandler, response, uriConverter);
-//        
+//
 //        cut.renderResource(null, response, wbRequest, result, headerResource, payloadResource, uriConverter, null);
-//        
+//
 //        EasyMock.verify(nodeHandler, response, uriConverter);
-//        
+//
 //        // NOTE: this compares output of Node.toHtml() with the original input.
 //        // there's a good chance of Node.toHtml() producing different text than original HTML.
 //        String out = servletOutput.getString();
 //        assertEquals("servlet output", payload, out);
-//        
+//
 //        ReplayParseContext context = parseContextCapture.getValue();
 //        // testing indirectly because ReplayParseContext has no method returning baseUrl.
 //        assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
 //    }
 
     public void testDoneFlagSetForFrameset() throws Exception {
-        String payload = "<frameset cols=\"25%,*,25%\">\n" + 
+        String payload = "<frameset cols=\"25%,*,25%\">\n" +
                 "  <frame src=\"top.html\">\n" +
                 "  <frame src=\"center.html\">\n" +
                 "  <frame src=\"bottom.html\">\n" +
                 "</frameset>\n";
         byte[] payloadBytes = payload.getBytes("UTF-8");
         Resource payloadResource = createTestHtmlResource(payloadBytes);
-        
+
         Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
         nodeHandler.handleParseStart(EasyMock.capture(parseContextCapture));
         nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
         nodeHandler.handleNode(EasyMock.<ParseContext>anyObject(), EasyMock.<Node>anyObject());
         EasyMock.expectLastCall().anyTimes();
-        
+
         // do not care about these expectations in this test.
         response.setStatus(200);
         response.setCharacterEncoding("utf-8");
         response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
         EasyMock.expectLastCall().anyTimes();
-        
+
         EasyMock.replay(nodeHandler, response, uriConverter);
 
         cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
-        
+
         EasyMock.verify(nodeHandler, response, uriConverter);
-        
+
         ReplayParseContext context = parseContextCapture.getValue();
         assertNotNull(context);
         // it's a kind of odd to use this constant defined in FastArchivalUrlReplayParseEventHandler.
@@ -292,37 +294,37 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         assertNotNull("FERRET_DONE flag is set",
                 context.getData(FastArchivalUrlReplayParseEventHandler.FERRET_DONE_KEY));
     }
-    
+
     public void testDoneFlagNotSetForFrameWrapperContext() throws Exception {
-        String payload = "<frameset cols=\"25%,*,25%\">\n" + 
+        String payload = "<frameset cols=\"25%,*,25%\">\n" +
                 "  <frame src=\"top.html\">\n" +
                 "  <frame src=\"center.html\">\n" +
                 "  <frame src=\"bottom.html\">\n" +
                 "</frameset>\n";
         byte[] payloadBytes = payload.getBytes("UTF-8");
         Resource payloadResource = createTestHtmlResource(payloadBytes);
-        
+
         Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
         nodeHandler.handleParseStart(EasyMock.capture(parseContextCapture));
         nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
         nodeHandler.handleNode(EasyMock.<ParseContext>anyObject(), EasyMock.<Node>anyObject());
         EasyMock.expectLastCall().anyTimes();
-        
+
         // do not care about these expectations in this test.
         response.setStatus(200);
         response.setCharacterEncoding("utf-8");
         response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
         EasyMock.expectLastCall().anyTimes();
-        
+
         EasyMock.replay(nodeHandler, response, uriConverter);
 
         // !!! KEY SETTING OF THIS TEST !!!
         wbRequest.setFrameWrapperContext(true);
-        
+
         cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
-        
+
         EasyMock.verify(nodeHandler, response, uriConverter);
-        
+
         ReplayParseContext context = parseContextCapture.getValue();
         assertNotNull(context);
         // it's kind of odd to use this constant defined in FastArchivalUrlReplayParseEventHandler.

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
@@ -1,0 +1,339 @@
+/**
+ * 
+ */
+package org.archive.wayback.archivalurl;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.archive.format.http.HttpHeaders;
+import org.archive.io.warc.TestWARCReader;
+import org.archive.io.warc.TestWARCRecordInfo;
+import org.archive.io.warc.WARCRecord;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.replay.RedirectRewritingHttpHeaderProcessor;
+import org.archive.wayback.replay.TextReplayRenderer;
+import org.archive.wayback.replay.TransparentReplayRendererTest.TestServletOutputStream;
+import org.archive.wayback.replay.charset.CharsetDetector;
+import org.archive.wayback.replay.html.ReplayParseContext;
+import org.archive.wayback.resourcestore.resourcefile.WarcResource;
+import org.archive.wayback.util.htmllex.ParseContext;
+import org.archive.wayback.util.htmllex.ParseEventHandler;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.htmlparser.Node;
+
+/**
+ * unit test for {@link ArchivalUrlSAXRewriteReplayRenderer}.
+ * @author kenji
+ *
+ */
+public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
+
+    ResultURIConverter uriConverter;
+    HttpServletResponse response;
+    ParseEventHandler nodeHandler;
+    WaybackRequest wbRequest;
+    CaptureSearchResult result;
+    TestServletOutputStream servletOutput = new TestServletOutputStream();
+    
+    ArchivalUrlSAXRewriteReplayRenderer cut;
+    
+    public static class TestParseEventHandler implements ParseEventHandler {
+        @Override
+        public void handleParseStart(ParseContext context) {
+        }
+        @Override
+        public void handleNode(ParseContext context, Node node)
+                throws IOException {
+            String html = node.toHtml();
+            //System.out.print(html);
+            ((ReplayParseContext) context).getOutputStream().write(
+                    html.getBytes("UTF-8"));
+        }
+        @Override
+        public void handleParseComplete(ParseContext context) {
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see junit.framework.TestCase#setUp()
+     */
+    protected void setUp() throws Exception {
+        super.setUp();
+        RedirectRewritingHttpHeaderProcessor httpHeaderProcessor = new RedirectRewritingHttpHeaderProcessor();
+        httpHeaderProcessor.setPrefix("X-Archive-Orig-");
+        
+        cut = new ArchivalUrlSAXRewriteReplayRenderer(httpHeaderProcessor);
+        
+        uriConverter = EasyMock.createMock(ResultURIConverter.class);
+        
+        response = EasyMock.createMock(HttpServletResponse.class);
+        EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+        
+        nodeHandler = EasyMock.createMock(ParseEventHandler.class);
+        cut.setDelegator(nodeHandler);
+        
+        wbRequest = new WaybackRequest();
+        wbRequest.setFrameWrapperContext(false);
+        
+        // replace default CharsetDetector (StandardCharsetDetector) with a stub 
+        // so as not to depend on its behavior.
+        cut.setCharsetDetector(new CharsetDetector() {
+            @Override
+            public String getCharset(Resource httpHeadersResource,
+                    Resource payloadResource, WaybackRequest wbRequest) {
+                return "UTF-8";
+            }
+        });
+        
+        result = new CaptureSearchResult();
+        result.setOriginalUrl("http://www.example.com/");
+    }
+    
+    public static Resource createTestHtmlResource(byte[] payloadBytes) throws IOException {
+        WARCRecordInfo recinfo = TestWARCRecordInfo.createCompressedHttpResponse("text/html", payloadBytes);
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        WarcResource resource = new WarcResource(rec, ar);
+        resource.parseHeaders();
+        return resource;
+    }
+    public static Resource createTestRevisitResource(byte[] payloadBytes, boolean withHeader, boolean gzipContent) throws IOException {
+        WARCRecordInfo recinfo = TestWARCRecordInfo.createRevisitHttpResponse(
+                "text/html", payloadBytes.length, withHeader, gzipContent);
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        WarcResource resource = new WarcResource(rec, ar);
+        resource.parseHeaders();
+        return resource;
+    }
+    
+    /**
+     * test basic behavior with simple input.
+     * expectations:
+     * <ul>
+     * <li>reads <em>decoded (uncompressed)</em> contents from archive record.</li>
+     * <li>calls delegator.handleParseStart() and handleParseComplete() just once, respectively.</li>
+     * <li>calls HttpServletResponse.setHeader() for Content-Type, Content-Length and 
+     *   {@link TextReplayRenderer#GUESSED_CHARSET_HEADER} (not configurable as with TextReplayRenderer
+     *   subclasses.</li>
+     * <li>calls HttpServletResponse.setCharsetEncoding() with value "utf-8"</li>
+     * <li>passes CaptureSearchResult.originalUrl to ParseContext.baseUrl</li>
+     * </ul>
+     * URL translation is not tested here because it is not a responsibility of this class.
+     * it should be tested in a test case for {@link ParseEventHandler} implementations.
+     * @throws Exception
+     */
+    public void testBasicBehavior() throws Exception {
+        String payload = "<HTML></HTML>\n";
+        final byte[] payloadBytes = payload.getBytes("UTF-8");
+        Resource payloadResource = createTestHtmlResource(payloadBytes);
+        
+        Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
+        Capture<Node> nodeCapture = new Capture<Node>();
+        nodeHandler.handleParseStart(EasyMock.<ReplayParseContext>anyObject());
+        nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
+        TestParseEventHandler delegate = new TestParseEventHandler();
+        nodeHandler.handleNode(EasyMock.capture(parseContextCapture), EasyMock.capture(nodeCapture));
+        EasyMock.expectLastCall().andDelegateTo(delegate).atLeastOnce();
+
+        response.setStatus(200);
+        response.setCharacterEncoding("utf-8");
+        response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
+        response.setHeader(TextReplayRenderer.GUESSED_CHARSET_HEADER, "UTF-8");
+        response.setHeader("Content-Type", "text/html");
+        response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        
+        EasyMock.replay(nodeHandler, response, uriConverter);
+        
+        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        
+        EasyMock.verify(nodeHandler, response, uriConverter);
+        
+        // NOTE: this compares output of Node.toHtml() with the original input.
+        // there's a good chance of Node.toHtml() producing different text than original HTML.
+        String out = servletOutput.getString();
+        assertEquals("servlet output", payload, out);
+        
+        ReplayParseContext context = parseContextCapture.getValue();
+        // testing indirectly because ReplayParseContext has no method returning baseUrl.
+        assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
+    }
+    
+    /**
+     * test revisit record (in new format with HTTP headers).
+     * @throws Exception
+     */
+    public void testRevisit() throws Exception {
+        final String payload = "<HTML></HTML>\n";
+        final byte[] payloadBytes = payload.getBytes("UTF-8");
+        Resource payloadResource = createTestHtmlResource(payloadBytes);
+        // payloadResource is Content-Encoding: gzip, revisit must be gzipped, too.
+        Resource headerResource = createTestRevisitResource(payloadBytes, true, true);
+
+        Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
+        Capture<Node> nodeCapture = new Capture<Node>();
+        nodeHandler.handleParseStart(EasyMock.<ReplayParseContext>anyObject());
+        nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
+        TestParseEventHandler delegate = new TestParseEventHandler();
+        nodeHandler.handleNode(EasyMock.capture(parseContextCapture), EasyMock.capture(nodeCapture));
+        EasyMock.expectLastCall().andDelegateTo(delegate).atLeastOnce();
+
+        response.setStatus(200);
+        response.setCharacterEncoding("utf-8");
+        response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
+        response.setHeader(TextReplayRenderer.GUESSED_CHARSET_HEADER, "UTF-8");
+        response.setHeader("Content-Type", "text/html");
+        response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        
+        EasyMock.replay(nodeHandler, response, uriConverter);
+        
+        cut.renderResource(null, response, wbRequest, result, headerResource, payloadResource, uriConverter, null);
+        
+        EasyMock.verify(nodeHandler, response, uriConverter);
+        
+        // NOTE: this compares output of Node.toHtml() with the original input.
+        // there's a good chance of Node.toHtml() producing different text than original HTML.
+        String out = servletOutput.getString();
+        assertEquals("servlet output", payload, out);
+        
+        ReplayParseContext context = parseContextCapture.getValue();
+        // testing indirectly because ReplayParseContext has no method returning baseUrl.
+        assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
+    }
+    
+    // no test for old-style revisit record as headerResource, because it is caller's responsibility to
+    // set headerResource = payloadResource in this case.
+    
+//    /**
+//     * test revisit record (in old format without HTTP headers).
+//     * @throws Exception
+//     */
+//    public void testOldRevisit() throws Exception {
+//        final String payload = "<HTML></HTML>\n";
+//        final byte[] payloadBytes = payload.getBytes("UTF-8");
+//        Resource payloadResource = createTestHtmlResource(payloadBytes);
+//        Resource headerResource = createTestRevisitResource(payloadBytes, false);
+//
+//        Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
+//        Capture<Node> nodeCapture = new Capture<Node>();
+//        nodeHandler.handleParseStart(EasyMock.<ReplayParseContext>anyObject());
+//        nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
+//        TestParseEventHandler delegate = new TestParseEventHandler();
+//        nodeHandler.handleNode(EasyMock.capture(parseContextCapture), EasyMock.capture(nodeCapture));
+//        EasyMock.expectLastCall().andDelegateTo(delegate).atLeastOnce();
+//
+//        response.setStatus(200);
+//        response.setCharacterEncoding("utf-8");
+//        response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
+//        response.setHeader(TextReplayRenderer.GUESSED_CHARSET_HEADER, "UTF-8");
+//        response.setHeader("Content-Type", "text/html");
+//        response.setHeader(EasyMock.matches("X-Archive-Orig-.*"), EasyMock.<String>notNull());
+//        EasyMock.expectLastCall().anyTimes();
+//        
+//        EasyMock.replay(nodeHandler, response, uriConverter);
+//        
+//        cut.renderResource(null, response, wbRequest, result, headerResource, payloadResource, uriConverter, null);
+//        
+//        EasyMock.verify(nodeHandler, response, uriConverter);
+//        
+//        // NOTE: this compares output of Node.toHtml() with the original input.
+//        // there's a good chance of Node.toHtml() producing different text than original HTML.
+//        String out = servletOutput.getString();
+//        assertEquals("servlet output", payload, out);
+//        
+//        ReplayParseContext context = parseContextCapture.getValue();
+//        // testing indirectly because ReplayParseContext has no method returning baseUrl.
+//        assertEquals("baseUrl is correctly set up", "http://www.example.com/a.html", context.resolve("a.html"));
+//    }
+
+    public void testDoneFlagSetForFrameset() throws Exception {
+        String payload = "<frameset cols=\"25%,*,25%\">\n" + 
+                "  <frame src=\"top.html\">\n" +
+                "  <frame src=\"center.html\">\n" +
+                "  <frame src=\"bottom.html\">\n" +
+                "</frameset>\n";
+        byte[] payloadBytes = payload.getBytes("UTF-8");
+        Resource payloadResource = createTestHtmlResource(payloadBytes);
+        
+        Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
+        nodeHandler.handleParseStart(EasyMock.capture(parseContextCapture));
+        nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
+        nodeHandler.handleNode(EasyMock.<ParseContext>anyObject(), EasyMock.<Node>anyObject());
+        EasyMock.expectLastCall().anyTimes();
+        
+        // do not care about these expectations in this test.
+        response.setStatus(200);
+        response.setCharacterEncoding("utf-8");
+        response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        
+        EasyMock.replay(nodeHandler, response, uriConverter);
+
+        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        
+        EasyMock.verify(nodeHandler, response, uriConverter);
+        
+        ReplayParseContext context = parseContextCapture.getValue();
+        assertNotNull(context);
+        // it's a kind of odd to use this constant defined in FastArchivalUrlReplayParseEventHandler.
+        // ArchivalUrlSAXRewriteReplayRenderer is supposed not to be tied with particular ParseEventHandler
+        // implementation.
+        assertNotNull("FERRET_DONE flag is set",
+                context.getData(FastArchivalUrlReplayParseEventHandler.FERRET_DONE_KEY));
+    }
+    
+    public void testDoneFlagNotSetForFrameWrapperContext() throws Exception {
+        String payload = "<frameset cols=\"25%,*,25%\">\n" + 
+                "  <frame src=\"top.html\">\n" +
+                "  <frame src=\"center.html\">\n" +
+                "  <frame src=\"bottom.html\">\n" +
+                "</frameset>\n";
+        byte[] payloadBytes = payload.getBytes("UTF-8");
+        Resource payloadResource = createTestHtmlResource(payloadBytes);
+        
+        Capture<ReplayParseContext> parseContextCapture = new Capture<ReplayParseContext>();
+        nodeHandler.handleParseStart(EasyMock.capture(parseContextCapture));
+        nodeHandler.handleParseComplete(EasyMock.<ReplayParseContext>anyObject());
+        nodeHandler.handleNode(EasyMock.<ParseContext>anyObject(), EasyMock.<Node>anyObject());
+        EasyMock.expectLastCall().anyTimes();
+        
+        // do not care about these expectations in this test.
+        response.setStatus(200);
+        response.setCharacterEncoding("utf-8");
+        response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        
+        EasyMock.replay(nodeHandler, response, uriConverter);
+
+        // !!! KEY SETTING OF THIS TEST !!!
+        wbRequest.setFrameWrapperContext(true);
+        
+        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        
+        EasyMock.verify(nodeHandler, response, uriConverter);
+        
+        ReplayParseContext context = parseContextCapture.getValue();
+        assertNotNull(context);
+        // it's kind of odd to use this constant defined in FastArchivalUrlReplayParseEventHandler.
+        // ArchivalUrlSAXRewriteReplayRenderer is supposed not to be tied with particular ParseEventHandler
+        // implementation.
+        assertNull("FERRET_DONE flag is NOT set",
+                context.getData(FastArchivalUrlReplayParseEventHandler.FERRET_DONE_KEY));
+    }
+
+    // TODO: more tests
+    // handles unescaped HTML entities in <script> element correctly (what exactly does "correctly" mean?)
+    // HttpServletResponse gets output in UTF-8, no matter what original encoding might be.
+
+}

--- a/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
@@ -1,0 +1,257 @@
+/**
+ * 
+ */
+package org.archive.wayback.replay;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.zip.GZIPInputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.archive.io.warc.TestWARCReader;
+import org.archive.io.warc.TestWARCRecordInfo;
+import org.archive.io.warc.WARCRecord;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.CaptureSearchResults;
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.resourcestore.resourcefile.WarcResource;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMock;
+
+/**
+ * unit test for {@link TransparentReplayRenderer}
+ * 
+ * @contributor kenji
+ *
+ */
+public class TransparentReplayRendererTest extends TestCase {
+
+    TransparentReplayRenderer cut;
+    // never used in TransparentReplayRenerer.
+    HttpServletRequest request = null;
+    HttpServletResponse response;
+    WaybackRequest wbRequest;
+    CaptureSearchResult result = new CaptureSearchResult();
+    ResultURIConverter uriConverter;
+    // unused in TransparentReplayRenderer.
+    CaptureSearchResults results = null;
+    
+    /* (non-Javadoc)
+     * @see junit.framework.TestCase#setUp()
+     */
+    protected void setUp() throws Exception {
+        super.setUp();
+        //HttpHeaderProcessor httpHeaderProcessor = new IdentityHttpHeaderProcessor();
+        HttpHeaderProcessor httpHeaderProcessor = new RedirectRewritingHttpHeaderProcessor();
+        cut = new TransparentReplayRenderer(httpHeaderProcessor);
+        // unused in TransparentReplayRenderer
+        wbRequest = null; //new WaybackRequest();
+        // use test fixture version as we want to focus on TransparentReplayRenderer behavior.
+        uriConverter = EasyMock.createMock(ResultURIConverter.class);
+        // result is only used in HttpHeaderOperation.processHeaders()
+        results = new CaptureSearchResults();
+        
+        response = EasyMock.createMock(HttpServletResponse.class);
+    }
+
+    public static class TestServletOutputStream extends ServletOutputStream {
+        ByteArrayOutputStream out =  new ByteArrayOutputStream();
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+        }
+        
+        public byte[] getBytes() {
+            return out.toByteArray();
+        }
+        public String getString() {
+            try {
+                return out.toString("UTF-8");
+            } catch (UnsupportedEncodingException ex) {
+                throw new RuntimeException("unexpected UnsupportedEncodingException", ex);
+            }
+        }
+    }
+    
+    public void testRenderResource_BasicCapture() throws Exception {
+        final String ct = "image/gif";
+        WARCRecordInfo recinfo = TestWARCRecordInfo.createHttpResponse(ct, TestWARCRecordInfo.PAYLOAD_GIF);
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        Resource payloadResource = new WarcResource(rec, ar);
+        payloadResource.parseHeaders();
+        Resource headersResource = payloadResource;
+        
+        TestServletOutputStream servletOutput = new TestServletOutputStream();
+        response.setStatus(200);
+        EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+        response.setHeader("Content-Type", ct);
+        // ??? RedirectRewritingHttpHeaderProcessor drops Content-Length header. is this really
+        // it is supposed to do?
+        //response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
+        response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(response);
+
+        cut.renderResource(request, response, wbRequest, result,
+                headersResource, payloadResource, uriConverter, results);
+        
+        EasyMock.verify(response);
+        byte[] content = servletOutput.getBytes();
+        assertTrue("servlet output", Arrays.equals(TestWARCRecordInfo.PAYLOAD_GIF, content));
+    }
+    
+    /**
+     * test replay of capture with {@code Content-Encoding: gzip}.
+     * TransparentReplayRenderer copies original, compressed payload to the output.
+     * 
+     * TODO: should render uncompressed content if client cannot handle
+     * {@code Content-Encoding: gzip}.
+     * 
+     * @throws Exception
+     */
+    public void testRenderResource_CompressedCapture() throws Exception {
+        final String ct = "image/gif";
+        WARCRecordInfo recinfo = new TestWARCRecordInfo(
+                TestWARCRecordInfo.buildCompressedHttpResponseBlock(ct,
+                        TestWARCRecordInfo.PAYLOAD_GIF));
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        Resource payloadResource = new WarcResource(rec, ar);
+        payloadResource.parseHeaders();
+        Resource headersResource = payloadResource;
+        
+        TestServletOutputStream servletOutput = new TestServletOutputStream();
+        response.setStatus(200);
+        EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+        response.setHeader("Content-Type", ct);
+        response.setHeader("Content-Encoding", "gzip");
+        // ??? RedirectRewritingHttpHeaderProcessor drops Content-Length header. is this really
+        // what it is supposed to do?
+        //response.setHeader("Content-Length", Integer.toString(payloadBytes.length));
+        response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(response);
+
+        cut.renderResource(request, response, wbRequest, result,
+                headersResource, payloadResource, uriConverter, results);
+        
+        EasyMock.verify(response);
+        
+        // content is the original gzip-compressed bytes for PAYLOAD_GIF.
+        InputStream zis = new GZIPInputStream(new ByteArrayInputStream(servletOutput.getBytes()));
+        byte[] content = new byte[TestWARCRecordInfo.PAYLOAD_GIF.length];
+        zis.read(content);
+        assertTrue("servlet output", Arrays.equals(TestWARCRecordInfo.PAYLOAD_GIF, content));
+    }    
+        
+    public void testRenderResource_Redirect() throws Exception {
+        String location = "http://www.example.com/index.html";
+        WARCRecordInfo recinfo = new TestWARCRecordInfo(TestWARCRecordInfo.buildHttpRedirectResponseBlock(location));
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        Resource payloadResource = new WarcResource(rec, ar);
+        payloadResource.parseHeaders();
+        
+        final String originalUrl = "http://www.example.com/";
+        final String captureTimestamp = "20130101123456";
+        
+        result.setOriginalUrl(originalUrl);
+        result.setCaptureTimestamp(captureTimestamp);
+        
+        // makeReplayURI() is called through RedirectRewritingHttpHeaderProcessor.
+        // TODO: perhaps HttpheaderProcessor is the right class to make fixture?
+        EasyMock.expect(uriConverter.makeReplayURI(captureTimestamp, location))
+        .andReturn("/web/" + captureTimestamp + "/" + location);
+
+        TestServletOutputStream servletOutput = new TestServletOutputStream();
+        response.setStatus(302);
+        EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+        response.setHeader("Content-Type", "text/html");
+        response.setHeader(EasyMock.eq("Location"), EasyMock.matches("/web/" + captureTimestamp + "/" + location));
+        // RedirectRewritingHttpHeaderProcessor drops Content-Length.
+        // response.setHeader("Content-Length", "0");
+        response.setHeader(EasyMock.<String>notNull(), EasyMock.<String>notNull());
+        EasyMock.expectLastCall().anyTimes();
+        
+        EasyMock.replay(response, uriConverter);
+
+        cut.renderResource(request, response, wbRequest, result,
+                payloadResource, payloadResource, uriConverter, results);
+        
+        EasyMock.verify(response, uriConverter);
+
+        byte[] content = servletOutput.getBytes();
+        assertEquals("payload length", 0, content.length);
+    }
+
+    /**
+     * test replay of capture with {@code Transfer-Encoding: chunked}.
+     *
+     * <p>TransparentReplayRenderer writes out chunk-decoded payload, because
+     * {@link WarcResource} always decodes chunked-entity. Point of this test
+     * is that response never have {@code Transfer-Encoding: chunked} header,
+     * even when initialized with {@link IdentityHttpHeaderProcessor}.
+     * so, this is not really a unit test for TransparentReplayRenderer, but
+     * a multi-component test placed here for convenience.</p>
+     * <p>This test does not use member object {@code cut}, in order to test
+     * with {@link IdentityHttpHeaderProcessor}.</p>
+     *
+     * @throws Exception
+     */
+    public void testRenderResource_Chunked() throws Exception {
+        final String ct = "text/xml";
+        final String payload = "<?xml version=\"1.0\"?>\n" +
+        		"<payload name=\"archive\">\n" +
+        		"  <inside/>\n" +
+        		"</payload>\n";
+        final byte[] recordBytes = TestWARCRecordInfo.buildHttpResponseBlock(
+        		"200 OK", ct, payload.getBytes("UTF-8"), true);
+        //System.out.println(new String(recordBytes, "UTF-8"));
+        WARCRecordInfo recinfo = new TestWARCRecordInfo(recordBytes);
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = ar.get(0);
+        Resource payloadResource = new WarcResource(rec, ar);
+        payloadResource.parseHeaders();
+        Resource headersResource = payloadResource;
+
+        TestServletOutputStream servletOutput = new TestServletOutputStream();
+        // expectations
+        response.setStatus(200);
+        EasyMock.expect(response.getOutputStream()).andReturn(servletOutput);
+        // capture setHeader() call for "Transfer-Encoding"
+        Capture<String> transferEncodingCapture = new Capture<String>(CaptureType.FIRST);
+        response.setHeader(EasyMock.eq("Transfer-Encoding"), EasyMock.capture(transferEncodingCapture));
+        EasyMock.expectLastCall().anyTimes();
+        response.setHeader(EasyMock.<String>anyObject(), EasyMock.<String>anyObject());
+        EasyMock.expectLastCall().anyTimes();
+
+        EasyMock.replay(response);
+
+        // creating separate test object to use IdentityHttpHeaderProcessor
+        TransparentReplayRenderer cut2 = new TransparentReplayRenderer(new IdentityHttpHeaderProcessor());
+        cut2.renderResource(request, response, wbRequest, result,
+        		headersResource, payloadResource, uriConverter, results);
+
+        EasyMock.verify(response);
+
+        assertFalse("Transfer-Encoding header must not be set", transferEncodingCapture.hasCaptured());
+
+        // content is the original gzip-compressed bytes for PAYLOAD_GIF.
+        String output = new String(servletOutput.getBytes(), "UTF-8");
+        assertEquals(payload, output);
+    }
+}


### PR DESCRIPTION
For the `wayback-core` module of openwayback, this is a _start_ at having our local modifications ONLY, with a maintainable approach.  All our local mods are not represented yet -- just a few to allow me to focus on having the uber maven build working properly.  

Note especially the commit organization and messages -- since I'm not bringing over the message history from sul-dlss/openwayback, this is the best I could think of to indicate local modifications.

Don't worry about broken travis yet - that won't work until I have more of this together - need travis to run uber pom for maven and be happy about all the pieces together:  our wayback-core, our wayback-webapp, upstream wayback-core classes, etc.

This is an intermediate PR … I do have maven running locally with tests passing for this "module".