### PR TITLE
top level maven build, including upstream-wayback-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: java
+sudo: false
+
+jdk:
+  - openjdk6 # wayback machine in production is actually hotspot 1.6.0
+  - openjdk7
+#  - oraclejdk7
+  - oraclejdk8
+
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - jdk: oraclejdk8
+
+script:
+  - mvn install test jacoco:report
+
+# Note:  currently no way to do this once for the entire matrix
+#  see https://github.com/travis-ci/travis-ci/issues/929
+after_success:
+  - mvn coveralls:report
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -50,10 +50,112 @@ Deployment is via deployment artifacts created at [jenkinsqa](https://jenkinsqa.
 
 ## Build
 ```
-mvn install
+mvn clean install
 ```
 
 ## Run Tests
 ```
 mvn test -B
 ```
+
+## Development
+
+FIXME: Top level directory ... blah blah
+
+
+Subdirectories:
+
+### upstream-wayback-core
+
+In order to create the final swap war file to deploy to a remote VM, we must ensure the java class loader won't have to choose between two versions of a class.
+
+We do this by REMOVING from the upstream IIPC wayback-core jar any class present in swap wayback-core code.
+
+```
+cd upstream-wayback-core
+mvn clean install
+```
+
+creates a jar file `upstream-wayback-core/target/openwayback-core-modified-[version].jar` identical to the IIPC openwayback-core jar, but without the Stanford modified classes in wayback-core.  It also installs said jar in the local maven repository (in `~/.m2/repository`) so it can be used by other `modules`, such as `wayback-core`.
+
+#### When making changes to wayback-core, be sure to update `assembly/distribution.xml`
+
+We must specify which classes to remove from the IIPC openwayback-core-modified.jar file by adding them to the `exclude` list in `upstream-wayback-core/assembly/distribution.xml`:
+
+```
+<assembly>
+...
+  <fileSets>
+    <fileSet>
+      ...
+      <excludes>
+        <exclude>**/ArchivalUrlSAXRewriteReplayRenderer.class</exclude>
+        <exclude>**/ToolBarData.class</exclude>
+      </excludes>
+      ...
+```
+
+This is how the maven-assembly-plugin will know what to exclude from `upstream-wayback-core/target/openwayback-core-modified-[version].jar`
+
+
+### wayback-core
+
+This contains only those classes with Stanford modifications, and any additional classes needed for testing.  The maven build
+
+```
+cd wayback-core
+mvn clean install
+```
+
+creates a jar file: `wayback-core/target/swap-wayback-core-[version].jar` which only contains
+our locally modified classes.
+
+There may be some WARNING messages from maven;  these can be ignored.  ERROR messages would be a problem.
+
+#### When making changes to wayback-core files, be sure to update `upstream-wayback-core/assembly/distribution.xml`
+
+We must specify which classes to remove from the IIPC openwayback-core-modified.jar file by adding them to the `exclude` list in `upstream-wayback-core/assembly/distribution.xml`.  See above (under upstream-wayback-core).
+
+
+### wayback-webapp
+
+This contains only those files with Stanford modifications;  we build a war file using the WAR overlay approach (see https://github.com/iipc/openwayback/wiki/Creating-a-WAR-overlay and https://maven.apache.org/plugins/maven-war-plugin/overlays.html).
+
+As with IIPC openwayback, maven builds a war file.
+
+```
+cd wayback-webapp
+mvn clean war:war  # actual goal, executed as part of package
+mvn clean install  # installs it in local repo for sibling builds to find
+```
+
+creates a war file in `wayback-webapp/target/swap-[version].war`.  This contains Stanford's modified webapp files and all additional upstream dependencies for the war file EXCEPT for wayback-core files.  We must add the wayback-core files in ourselves to get our local modifications.
+
+#### To make changes to wayback-webapp ...
+
+FIXME:  blah blah
+
+
+
+### wayback-cdx-server
+
+Stanford puppet deploys the cdx-server war file, so this is a way for our maven build to create one.  (TODO: possibly just download the artifact from a maven repo?).  
+
+```
+cd wayback-cdx-server
+mvn clean package
+```
+
+creates a jar file `wayback-cdx-server/target/openwaybck-cdx-server-[version].war` which can be deployed by puppet.  Currently we do this via a jenkins build.  (FIXME:  add details about jenkins)
+
+
+###  dist or top level build or ... FIXME:
+
+FIXME:  blah blah
+
+```
+cd dist
+mvn clean dependency:unpack assembly:single
+```
+
+takes the war file from `wayback-webapp/target/swap-[version].war` and adds in `wayback-core/target/swap-wayback-core-[version].jar` and `openwayback-core/target/openwayback-core-modified-[version].jar`.  This war file is a deployable artifact that contains Stanford modifications to the upstream IIPC openwayback code.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Rough list of Stanford changes (see also sul-dlss/openwayback):
   - next/prev remembers user prefs
 
 devopsy:
-- run continous integration for OUR build
+- run continuous integration for OUR build
 - get code coverage for OUR build
 - update README
 - CONTRIBUTING doc
@@ -46,26 +46,42 @@ For more documentation on this code, see [the OpenWayback wiki](https://github.c
 
 Deployment is via deployment artifacts created at [jenkinsqa](https://jenkinsqa.stanford.edu/job/was-swap/).  These artifacts are deployed to:
 - to sul-wayback-xxx VMs by puppet
-- was-robot VMs as part of capistrano [deployment tasks in `was_robot_suite`](https://github.com/sul-dlss/was_robot_suite/blob/master/config/deploy.rb#L47-L54). The deployed `was_robot_suite` houses the deployed files in the `jar/openwayback` directory.
 
-## Build
+
+## Development
+
+The code is organized in the same way as IIPC openwayback:  The top directory holds the maven build for all the modules represented by subdirectories.  
+
+### Build
+
+You can build all the code using maven from the top directory.
+
 ```
 mvn clean install
 ```
 
+You can also run maven builds for individual steps from within their subdirectory.
+
+
 ## Run Tests
+
+You can run tests the usual way with maven:
+
 ```
 mvn test -B
 ```
 
-## Development
+You can create a coverage report:
 
-FIXME: Top level directory ... blah blah
+```
+mvn test jacoco:report
+```
 
+See also `.travis.yml`
 
-Subdirectories:
+### Subdirectories:
 
-### upstream-wayback-core
+#### upstream-wayback-core
 
 In order to create the final swap war file to deploy to a remote VM, we must ensure the java class loader won't have to choose between two versions of a class.
 
@@ -78,7 +94,7 @@ mvn clean install
 
 creates a jar file `upstream-wayback-core/target/openwayback-core-modified-[version].jar` identical to the IIPC openwayback-core jar, but without the Stanford modified classes in wayback-core.  It also installs said jar in the local maven repository (in `~/.m2/repository`) so it can be used by other `modules`, such as `wayback-core`.
 
-#### When making changes to wayback-core, be sure to update `assembly/distribution.xml`
+##### When making changes to wayback-core, be sure to update `assembly/distribution.xml`
 
 We must specify which classes to remove from the IIPC openwayback-core-modified.jar file by adding them to the `exclude` list in `upstream-wayback-core/assembly/distribution.xml`:
 
@@ -98,7 +114,7 @@ We must specify which classes to remove from the IIPC openwayback-core-modified.
 This is how the maven-assembly-plugin will know what to exclude from `upstream-wayback-core/target/openwayback-core-modified-[version].jar`
 
 
-### wayback-core
+#### wayback-core
 
 This contains only those classes with Stanford modifications, and any additional classes needed for testing.  The maven build
 
@@ -112,12 +128,12 @@ our locally modified classes.
 
 There may be some WARNING messages from maven;  these can be ignored.  ERROR messages would be a problem.
 
-#### When making changes to wayback-core files, be sure to update `upstream-wayback-core/assembly/distribution.xml`
+##### When making changes to wayback-core files, be sure to update `upstream-wayback-core/assembly/distribution.xml`
 
 We must specify which classes to remove from the IIPC openwayback-core-modified.jar file by adding them to the `exclude` list in `upstream-wayback-core/assembly/distribution.xml`.  See above (under upstream-wayback-core).
 
 
-### wayback-webapp
+#### wayback-webapp
 
 This contains only those files with Stanford modifications;  we build a war file using the WAR overlay approach (see https://github.com/iipc/openwayback/wiki/Creating-a-WAR-overlay and https://maven.apache.org/plugins/maven-war-plugin/overlays.html).
 
@@ -131,13 +147,13 @@ mvn clean install  # installs it in local repo for sibling builds to find
 
 creates a war file in `wayback-webapp/target/swap-[version].war`.  This contains Stanford's modified webapp files and all additional upstream dependencies for the war file EXCEPT for wayback-core files.  We must add the wayback-core files in ourselves to get our local modifications.
 
-#### To make changes to wayback-webapp ...
+##### To make changes to wayback-webapp ...
 
 FIXME:  blah blah
 
 
 
-### wayback-cdx-server
+#### wayback-cdx-server
 
 Stanford puppet deploys the cdx-server war file, so this is a way for our maven build to create one.  (TODO: possibly just download the artifact from a maven repo?).  
 
@@ -149,7 +165,7 @@ mvn clean package
 creates a jar file `wayback-cdx-server/target/openwaybck-cdx-server-[version].war` which can be deployed by puppet.  Currently we do this via a jenkins build.  (FIXME:  add details about jenkins)
 
 
-###  dist or top level build or ... FIXME:
+####  dist or top level build or ... FIXME:
 
 FIXME:  blah blah
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,201 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
+  <groupId>edu.stanford.dlss</groupId>
+  <artifactId>stanford-web-archiving-portal</artifactId>
+  <packaging>pom</packaging>
+  <version>2.0.0</version>
+  <name>Stanford's OpenWayback Instance</name>
+
+  <modules>
+    <!-- <module>wayback-cdx-server</module> -->
+    <module>upstream-wayback-core</module>
+    <module>wayback-core</module>
+    <module>wayback-webapp</module>
+    <!-- <module>dist</module> -->
+  </modules>
+
+  <properties>
+    <website.url>http://github.com/sul-dlss/swap</website.url>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <description>
+    Stanford University Libraries version of [iip/openwayback](https://github.com/iipc/openwayback), a java application to query and access archived web material. This is the code for the Stanford Web Archiving Portal (SWAP).
+  </description>
+
+  <url>http://github.com/sul-dlss/swap</url>
+
+  <repositories>
+    <repository>
+      <id>oss.sonatype.org</id>
+      <name>OSS Sonatype</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.8</version>
+        <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.6.1</version>
+          <!-- <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration> -->
+        </plugin>
+        <!-- <plugin>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>maven-jetty-plugin</artifactId>
+          <version>6.1.22</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jxr-plugin</artifactId>
+          <version>2.4</version>
+        </plugin> -->
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Link all child module version dependencies to the parent POM version. -->
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>upstream-wayback-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>swap-wayback-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <!-- <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>swap-wayback-webapp</artifactId>
+        <version>${project.version}</version>
+      </dependency> -->
+      <dependency>
+        <!-- <groupId>${project.groupId}</groupId> -->
+        <groupId>org.netpreserve.openwayback</groupId>
+        <artifactId>openwayback-cdx-server</artifactId>
+        <version>${project.version}</version>
+        <type>war</type>
+        <!-- <type>jar</type> -->
+        <!-- <classifier>classes</classifier> -->
+      </dependency>
+      <!-- <dependency>
+        <groupId>org.netpreserve.openwayback</groupId>
+        <artifactId>openwayback-core</artifactId>
+        <version>${project.version}</version>
+      </dependency> -->
+
+      <dependency>
+        <groupId>org.netpreserve.commons</groupId>
+        <artifactId>webarchive-commons</artifactId>
+        <version>1.1.4</version>
+      </dependency>
+      <!-- <dependency>
+        <groupId>org.netpreserve.openwayback</groupId>
+        <artifactId>openwayback-access-control-core</artifactId>
+        <version>1.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.googlecode.juniversalchardet</groupId>
+        <artifactId>juniversalchardet</artifactId>
+        <version>1.0.3</version>
+      </dependency> -->
+
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>2.5</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.htmlparser</groupId>
+        <artifactId>htmlparser</artifactId>
+        <version>1.6</version>
+      </dependency>
+
+      <!-- <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${org.springframework.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.flagstone</groupId>
+        <artifactId>transform</artifactId>
+        <version>3.0.2</version>
+      </dependency> -->
+
+      <!-- test dependencies -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>3.8.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.agent</artifactId>
+        <classifier>runtime</classifier>
+        <version>0.7.8</version>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/upstream-wayback-core/assembly/distribution.xml
+++ b/upstream-wayback-core/assembly/distribution.xml
@@ -1,0 +1,29 @@
+<assembly>
+  <id>upstream-wayback-core</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>${project.build.directory}/repacked-jar</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/unpacked-jar</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>**/*.class</include>
+        <include>META-INF/*</include>
+      </includes>
+      <excludes>
+        <exclude>**/ArchivalUrlSAXRewriteReplayRenderer.class</exclude>
+        <exclude>**/ToolBarData.class</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+
+</assembly>

--- a/upstream-wayback-core/pom.xml
+++ b/upstream-wayback-core/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>edu.stanford.dlss</groupId>
+    <artifactId>stanford-web-archiving-portal</artifactId>
+    <version>2.0.0</version>
+  </parent>
+
+  <artifactId>upstream-wayback-core</artifactId>
+  <name>IIPC OpenWayback Core Jar minus classes in swap-wayback-core.jar</name>
+  <packaging>jar</packaging>
+  <version>2.0.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <artifactItems>
+            <artifactItem>
+              <groupId>org.netpreserve.openwayback</groupId>
+              <artifactId>openwayback-core</artifactId>
+              <version>${project.parent.version}</version>
+              <type>jar</type>
+              <outputDirectory>${project.build.directory}/unpacked-jar</outputDirectory>
+            </artifactItem>
+          </artifactItems>
+        </configuration>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <descriptors>
+            <descriptor>assembly/distribution.xml</descriptor>
+          </descriptors>
+          <finalName>openwayback-core-modified-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -16,30 +16,48 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.netpreserve.openwayback</groupId>
-      <artifactId>openwayback-cdx-server</artifactId>
-      <classifier>classes</classifier>
-      <version>${project.version}</version>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>upstream-wayback-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.netpreserve.openwayback</groupId>
-      <artifactId>openwayback-core</artifactId>
-      <version>${project.version}</version>
+      <artifactId>openwayback-cdx-server</artifactId>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.netpreserve.commons</groupId>
+      <artifactId>webarchive-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.htmlparser</groupId>
+      <artifactId>htmlparser</artifactId>
     </dependency>
     <dependency>
     	<groupId>javax.mail</groupId>
     	<artifactId>mail</artifactId>
     	<version>1.4.7</version>
     </dependency>
+
+    <!-- test dependencies -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <scope>provided</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>2.5.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>3.0.6.RELEASE</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>openwayback</artifactId>
-    <groupId>org.netpreserve.openwayback</groupId>
+    <groupId>edu.stanford.dlss</groupId>
+    <artifactId>stanford-web-archiving-portal</artifactId>
     <version>2.0.0</version>
   </parent>
 

--- a/wayback-webapp/pom.xml
+++ b/wayback-webapp/pom.xml
@@ -1,11 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>stanford-web-archiving-portal</artifactId>
-  <groupId>edu.stanford.dlss</groupId>
+
+  <parent>
+    <groupId>edu.stanford.dlss</groupId>
+    <artifactId>stanford-web-archiving-portal</artifactId>
+    <version>2.0.0</version>
+  </parent>
+
+  <artifactId>swap-wayback-webapp</artifactId>
   <packaging>war</packaging>
   <name>Stanford Web Archiving Portal Overlay</name>
-  <version>2.0.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
`upstream-wayback-core` is just repackaging IIPC wayback-core jar withOUT stanford modified files -- this will avoid class name clashes for our locally modified files.

The `wayback-core` build has been modified to depend on the `upstream-wayback-core` jar.

Also added is the top level maven build, using the "module" approach, and updates to README.

This is some of the plumbing needed to 
- only have our local modifications in this git repo, 
- be able to build deployable artifacts.   

All our local mods in sul-dlss/openwayback are not represented yet -- just a subset to allow me to focus on getting the plumbing right..