### PR TITLE
build deployable swap war artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
   allow_failures:
     - jdk: oraclejdk8
 
+install:
+  - mvn clean -B -V
 script:
-  - mvn install test jacoco:report
+  - mvn install jacoco:report -Dmaven.javadoc.skip=true -B -V
 
 # Note:  currently no way to do this once for the entire matrix
 #  see https://github.com/travis-ci/travis-ci/issues/929

--- a/dist/assembly/distribution.xml
+++ b/dist/assembly/distribution.xml
@@ -1,0 +1,36 @@
+<assembly>
+  <id>dist-swap-$version</id>
+  <formats>
+    <format>war</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>edu.stanford.dlss:swap-wayback-core</include>
+        <include>edu.stanford.dlss:upstream-wayback-core</include>
+      </includes>
+      <binaries>
+        <outputDirectory>modules/maven-assembly-plugin</outputDirectory>
+        <unpack>false</unpack>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>${project.build.directory}/repacked-war</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/unpacked-war</directory>
+      <outputDirectory />
+    </fileSet>
+  </fileSets>
+
+</assembly>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>edu.stanford.dlss</groupId>
+    <artifactId>stanford-web-archiving-portal</artifactId>
+    <version>2.0.0</version>
+  </parent>
+
+  <artifactId>swap-distrib</artifactId>
+  <name>swap.war for distribution</name>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>swap-wayback-webapp</artifactId>
+      <version>${project.parent.version}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>swap-wayback-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>upstream-wayback-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <artifactItems>
+            <artifactItem>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>swap-wayback-webapp</artifactId>
+              <version>${project.parent.version}</version>
+              <type>war</type>
+              <outputDirectory>${project.build.directory}/unpacked-war</outputDirectory>
+            </artifactItem>
+          </artifactItems>
+        </configuration>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <descriptors>
+            <descriptor>assembly/distribution.xml</descriptor>
+          </descriptors>
+          <finalName>swap-dist-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,26 +80,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.1</version>
-          <!-- <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-          </configuration> -->
         </plugin>
-        <!-- <plugin>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>maven-jetty-plugin</artifactId>
-          <version>6.1.22</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>2.7</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jxr-plugin</artifactId>
-          <version>2.4</version>
-        </plugin> -->
       </plugins>
     </pluginManagement>
   </build>
@@ -123,35 +104,16 @@
         <version>${project.version}</version>
       </dependency> -->
       <dependency>
-        <!-- <groupId>${project.groupId}</groupId> -->
         <groupId>org.netpreserve.openwayback</groupId>
         <artifactId>openwayback-cdx-server</artifactId>
         <version>${project.version}</version>
         <type>war</type>
-        <!-- <type>jar</type> -->
-        <!-- <classifier>classes</classifier> -->
       </dependency>
-      <!-- <dependency>
-        <groupId>org.netpreserve.openwayback</groupId>
-        <artifactId>openwayback-core</artifactId>
-        <version>${project.version}</version>
-      </dependency> -->
-
       <dependency>
         <groupId>org.netpreserve.commons</groupId>
         <artifactId>webarchive-commons</artifactId>
         <version>1.1.4</version>
       </dependency>
-      <!-- <dependency>
-        <groupId>org.netpreserve.openwayback</groupId>
-        <artifactId>openwayback-access-control-core</artifactId>
-        <version>1.0.2</version>
-      </dependency>
-      <dependency>
-        <groupId>com.googlecode.juniversalchardet</groupId>
-        <artifactId>juniversalchardet</artifactId>
-        <version>1.0.3</version>
-      </dependency> -->
 
       <dependency>
         <groupId>javax.servlet</groupId>
@@ -164,22 +126,6 @@
         <artifactId>htmlparser</artifactId>
         <version>1.6</version>
       </dependency>
-
-      <!-- <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${org.springframework.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-        <version>${org.springframework.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.flagstone</groupId>
-        <artifactId>transform</artifactId>
-        <version>3.0.2</version>
-      </dependency> -->
 
       <!-- test dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <module>upstream-wayback-core</module>
     <module>wayback-core</module>
     <module>wayback-webapp</module>
-    <!-- <module>dist</module> -->
+    <module>dist</module>
   </modules>
 
   <properties>

--- a/upstream-wayback-core/assembly/distribution.xml
+++ b/upstream-wayback-core/assembly/distribution.xml
@@ -14,7 +14,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}/unpacked-jar</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory />
       <includes>
         <include>**/*.class</include>
         <include>META-INF/*</include>

--- a/wayback-webapp/pom.xml
+++ b/wayback-webapp/pom.xml
@@ -35,44 +35,6 @@
           </overlays>
         </configuration>
       </plugin>
-<!--
-      <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.22</version>
-        <configuration>
-          <systemProperties>
-            <systemProperty>
-              <name>jetty.port</name>
-              <value>${wayback.port}</value>
-            </systemProperty>
-          </systemProperties>
-          <webAppConfig>
-            <contextPath>/</contextPath>
-          </webAppConfig>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
-          <scanTargetPatterns>
-            <scanTargetPattern>
-              <directory>src/main/webapp</directory>
-              <directory>src/main/java</directory>
-              <includes>
-                <include>**/*.properties</include>
-                <include>**/*.java</include>
-                <include>**/*.xml</include>
-              </includes>
--->
-              <!-- JSPs are updated on the fly anyway, don't require webapp restart -->
-<!--
-              <excludes>
-                <exclude>**/*.jsp</exclude>
-              </excludes>
-            </scanTargetPattern>
-          </scanTargetPatterns>
-          <stopKey>foo</stopKey>
-          <stopPort>${jetty.stopPort}</stopPort>
-        </configuration>
-      </plugin>
--->
     </plugins>
   </build>
 
@@ -85,10 +47,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.netpreserve.openwayback</groupId>
-      <artifactId>openwayback-core</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>swap-wayback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>upstream-wayback-core</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Note:  the artifact being built does NOT include all of our localizations -- this is another step towards getting all the plumbing set up so we can build the artifacts puppet needs.

- added dist maven module to produce swap.war file for distribution
- cleaned up maven build
  - webapp uses localized builds (with local changes) instead of upstream builds)
  - upstream core avoids error message
- cleaned up travis build - avoid unnecessary steps

Connects to #6