### PR TITLE
upstream-wayback-core distribution.xml: include properties files

### DIFF
--- a/upstream-wayback-core/assembly/distribution.xml
+++ b/upstream-wayback-core/assembly/distribution.xml
@@ -17,6 +17,7 @@
       <outputDirectory />
       <includes>
         <include>**/*.class</include>
+        <include>**/*.properties</include>
         <include>META-INF/*</include>
       </includes>
       <excludes>


### PR DESCRIPTION
We need to include any ```xxxx.properties``` files from upstream wayback-core.

connects to #8 and sul-dlss/operations-tasks/issues/663