### PR TITLE
pom.xml files: version separates upstream and stanford versions

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.stanford.dlss</groupId>
     <artifactId>stanford-web-archiving-portal</artifactId>
-    <version>2.0.0</version>
+    <version>${stanford.version}</version>
   </parent>
 
   <artifactId>swap-distrib</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,17 @@
     <version>7</version>
   </parent>
 
+  <properties>
+    <website.url>http://github.com/sul-dlss/swap</website.url>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <upstream.version>2.0.0</upstream.version>
+    <stanford.version>${upstream.version}SUL1.0.0</stanford.version>
+  </properties>
+
   <groupId>edu.stanford.dlss</groupId>
   <artifactId>stanford-web-archiving-portal</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>${stanford.version}</version>
   <name>Stanford's OpenWayback Instance</name>
 
   <modules>
@@ -20,11 +27,6 @@
     <module>wayback-webapp</module>
     <module>dist</module>
   </modules>
-
-  <properties>
-    <website.url>http://github.com/sul-dlss/swap</website.url>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 
   <description>
     Stanford University Libraries version of [iip/openwayback](https://github.com/iipc/openwayback), a java application to query and access archived web material. This is the code for the Stanford Web Archiving Portal (SWAP).
@@ -106,7 +108,7 @@
       <dependency>
         <groupId>org.netpreserve.openwayback</groupId>
         <artifactId>openwayback-cdx-server</artifactId>
-        <version>${project.version}</version>
+        <version>${upstream.version}</version>
         <type>war</type>
       </dependency>
       <dependency>

--- a/upstream-cdx-server/pom.xml
+++ b/upstream-cdx-server/pom.xml
@@ -7,14 +7,15 @@
   <parent>
     <groupId>edu.stanford.dlss</groupId>
     <artifactId>stanford-web-archiving-portal</artifactId>
-    <version>2.0.0</version>
+    <version>${stanford.version}</version>
+    <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.netpreserve.openwayback</groupId>
   <artifactId>openwayback-cdx-server</artifactId>
   <packaging>war</packaging>
   <name>Wayback CDX Server (no Stanford changes)</name>
-  <version>2.0.0</version>
+  <version>${upstream.version}</version>
 
   <build>
     <plugins>
@@ -38,6 +39,7 @@
     <dependency>
       <groupId>org.netpreserve.openwayback</groupId>
       <artifactId>openwayback-cdx-server</artifactId>
+      <version>${upstream.version}</version>
       <type>war</type>
     </dependency>
   </dependencies>

--- a/upstream-wayback-core/pom.xml
+++ b/upstream-wayback-core/pom.xml
@@ -5,13 +5,14 @@
   <parent>
     <groupId>edu.stanford.dlss</groupId>
     <artifactId>stanford-web-archiving-portal</artifactId>
-    <version>2.0.0</version>
+    <version>${stanford.version}</version>
+    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>upstream-wayback-core</artifactId>
   <name>IIPC OpenWayback Core Jar minus classes in swap-wayback-core.jar</name>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>${stanford.version}</version>
 
   <build>
     <plugins>
@@ -24,7 +25,7 @@
             <artifactItem>
               <groupId>org.netpreserve.openwayback</groupId>
               <artifactId>openwayback-core</artifactId>
-              <version>${project.parent.version}</version>
+              <version>${upstream.version}</version>
               <type>jar</type>
               <outputDirectory>${project.build.directory}/unpacked-jar</outputDirectory>
             </artifactItem>

--- a/wayback-core/pom.xml
+++ b/wayback-core/pom.xml
@@ -5,13 +5,14 @@
   <parent>
     <groupId>edu.stanford.dlss</groupId>
     <artifactId>stanford-web-archiving-portal</artifactId>
-    <version>2.0.0</version>
+    <version>${stanford.version}</version>
+    <relativePath>..</relativePath>
   </parent>
 
   <groupId>edu.stanford.dlss</groupId>
   <artifactId>swap-wayback-core</artifactId>
   <name>Stanford Specific Wayback Core Java Classes</name>
-  <version>2.0.0</version>
+  <version>${stanford.version}</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -22,6 +23,7 @@
     <dependency>
       <groupId>org.netpreserve.openwayback</groupId>
       <artifactId>openwayback-cdx-server</artifactId>
+      <version>${upstream.version}</version>
       <type>war</type>
     </dependency>
     <dependency>

--- a/wayback-webapp/pom.xml
+++ b/wayback-webapp/pom.xml
@@ -45,19 +45,19 @@
     </dependency>
 
     <dependency>
-      <groupId>org.netpreserve.openwayback</groupId>
-      <artifactId>openwayback-webapp</artifactId>
-      <version>${project.version}</version>
-      <type>war</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>swap-wayback-core</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>upstream-wayback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.netpreserve.openwayback</groupId>
+      <artifactId>openwayback-webapp</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/wayback-webapp/pom.xml
+++ b/wayback-webapp/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <groupId>edu.stanford.dlss</groupId>
     <artifactId>stanford-web-archiving-portal</artifactId>
-    <version>2.0.0</version>
+    <version>${stanford.version}</version>
+    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>swap-wayback-webapp</artifactId>
@@ -25,7 +26,7 @@
               <groupId>org.netpreserve.openwayback</groupId>
               <artifactId>openwayback-webapp</artifactId>
               <excludes>
-                <exclude>WEB-INF/lib/openwayback-core-${project.version}.jar</exclude>
+                <exclude>WEB-INF/lib/openwayback-core-${upstream.version}.jar</exclude>
                 <!-- exclude the vulnerable commons-collections v3.2.1 -->
                 <exclude>WEB-INF/lib/commons-collections-3.2.1.jar</exclude>
               </excludes>
@@ -55,7 +56,7 @@
     <dependency>
       <groupId>org.netpreserve.openwayback</groupId>
       <artifactId>openwayback-webapp</artifactId>
-      <version>${project.version}</version>
+      <version>${upstream.version}</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
This allows the jenkinsqa deployed artifact version numbers to be unique for stanford only changes and for upstream only changes.

connected to #28 