### PR TITLE
Set anonymizeIP true for Google Analytics

### DIFF
--- a/wayback-webapp/src/main/webapp/WEB-INF/replay/Toolbar.jsp
+++ b/wayback-webapp/src/main/webapp/WEB-INF/replay/Toolbar.jsp
@@ -513,6 +513,7 @@ String starLink = fmt.escapeHtml(queryPrefix + wbRequest.getReplayTimestamp() + 
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-7219229-29', 'auto');
+  ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>
 

--- a/wayback-webapp/src/main/webapp/WEB-INF/template/UI-header.jsp
+++ b/wayback-webapp/src/main/webapp/WEB-INF/template/UI-header.jsp
@@ -45,6 +45,7 @@ String replayPrefix = results.getReplayPrefix();
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-7219229-29', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </head>


### PR DESCRIPTION
A friendly PR to anonymizeIP for swap.stanford.edu as we do this throughout our public portfolio

